### PR TITLE
Add another Exeucutor.apply overload.

### DIFF
--- a/src/main/scala/execution.scala
+++ b/src/main/scala/execution.scala
@@ -26,6 +26,9 @@ trait Executor {
   /** Timeout for promises made by this HTTP Executor */
   def timeout: Duration
 
+  def apply(builder: RequestBuilder): Promise[Response] =
+    apply(builder.build() -> new FunctionHandler(identity))
+
   def apply[T](pair: (Request, AsyncHandler[T])): Promise[T] =
     apply(pair._1, pair._2)
 

--- a/src/test/scala/basic.scala
+++ b/src/test/scala/basic.scala
@@ -7,7 +7,7 @@ extends Properties("Basic")
 with unfiltered.spec.ServerCleanup {
   import Prop.forAll
 
-  val server = { 
+  val server = {
     import unfiltered.netty
     import unfiltered.response._
     import unfiltered.request._
@@ -28,10 +28,18 @@ with unfiltered.spec.ServerCleanup {
     )
     res() == ("POST" + sample)
   }
+
   property("GET and handle") = forAll(Gen.alphaStr) { (sample: String) =>
     val res = Http(
       localhost / "echo" <<? Map("echo" -> sample) > As.string
     )
     res() == ("GET" + sample)
+  }
+
+  property("GET and get response") = forAll(Gen.alphaStr) { (sample: String) =>
+    val res = Http(
+      localhost / "echo" <<? Map("echo" -> sample)
+    )
+    res().getResponseBody == ("GET" + sample)
   }
 }


### PR DESCRIPTION
This is just a shortcut for a handler that simply returns
the response (whatever the status code is) like:

  val resp: Promise[Response] = Http(url > new FunctionHandler { r => r })

Instead you can now do:

  val resp: Promise[Response] = Http(url)

Essentially that means not building an explicit handler results in a
plain handler for a Promise[Response].

Alternatively (or additionally?) there could be As.response (not part of this PR).
