### PR TITLE
Bump AHC to 1.7.1.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ description :=
   "Core Dispatch module wrapping sonatype/async-http-client"
 
 libraryDependencies ++= Seq(
-  "com.ning" % "async-http-client" % "1.7.0",
+  "com.ning" % "async-http-client" % "1.7.1",
   "net.databinder" %% "unfiltered-netty-server" % "0.6.1" % "test",
   "org.slf4j" % "slf4j-simple" % "1.6.4" % "test"
 )


### PR DESCRIPTION
AHC 1.7.1 uses netty 3.3.1 which is then the same as in unfiltered 0.6.1,
avoiding two different netty versions on the classpath when using
unfiltered 0.6.1 in combination with dispatch/reboot.
