### PR TITLE
bring ahc dep up to version 1.7.4

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,5 +4,5 @@ description :=
   "Core Dispatch module wrapping sonatype/async-http-client"
 
 libraryDependencies ++= Seq(
-  "com.ning" % "async-http-client" % "1.7.1"
+  "com.ning" % "async-http-client" % "1.7.4"
 )


### PR DESCRIPTION
Updating ahc dep. This fixes a number of bugs in the underlying client that could trickle up to the dispatch interface. I've ran into at least one

Below are the changesets for each of the minor version bumps
- [1.7.2](https://github.com/sonatype/async-http-client/issues?direction=desc&labels=1.7.2&milestone=&page=1&sort=created&state=closed)
- [1.7.3](https://github.com/sonatype/async-http-client/issues?direction=desc&labels=1.7.3&milestone=&page=1&sort=created&state=closed)
- [1.7.4](https://github.com/sonatype/async-http-client/issues?direction=desc&labels=1.7.4&milestone=&page=1&sort=created&state=closed)
