### PR TITLE
bump ahc version to 1.7.5

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,7 +4,7 @@ description :=
   "Core Dispatch module wrapping sonatype/async-http-client"
 
 libraryDependencies ++= Seq(
-  "com.ning" % "async-http-client" % "1.7.4"
+  "com.ning" % "async-http-client" % "1.7.5"
 )
 
 seq(lsSettings :_*)


### PR DESCRIPTION
This is the latest and has [these changes](https://github.com/sonatype/async-http-client/compare/async-http-client-1.7.4...async-http-client-1.7.5) which include a bump in netty versions (same one uf depends on) and some websockets fixes. At some point I'd like to adapt that to a dispatch interface.
