### PR TITLE
Remove unused as.File constructor parameter.

### DIFF
--- a/core/src/main/scala/as/core.scala
+++ b/core/src/main/scala/as/core.scala
@@ -17,7 +17,7 @@ object Bytes extends (client.Response => Array[Byte]) {
 }
 
 object File extends {
-  def apply(file: java.io.File)(r: client.Response) =
+  def apply(file: java.io.File) =
     (new client.resumable.ResumableAsyncHandler with OkHandler[Nothing])
       .setResumableListener(
         new client.extra.ResumableRandomAccessFileListener(


### PR DESCRIPTION
Otherwise if filled-in or curried then the actual file download handler
is not invoked.
