### PR TITLE
Add reason-phrase to status case class for additional diagnostic

### DIFF
--- a/core/src/main/scala/handlers.scala
+++ b/core/src/main/scala/handlers.scala
@@ -19,8 +19,8 @@ class RequestHandlerTupleBuilder(builder: RequestBuilder) {
     (builder.build(), h)
 }
 
-case class StatusCode(code: Int)
-extends Exception("Unexpected response status: %d".format(code))
+case class StatusCode(code: Int, reason: String)
+extends Exception("Unexpected response status: %d %s".format(code, reason))
 
 class FunctionHandler[T](f: Response => T) extends AsyncCompletionHandler[T] {
   def onCompleted(response: Response) = f(response)
@@ -34,7 +34,7 @@ trait OkHandler[T] extends AsyncHandler[T] {
     if (status.getStatusCode / 100 == 2)
       super.onStatusReceived(status)
     else
-      throw StatusCode(status.getStatusCode)
+      throw StatusCode(status.getStatusCode, status.getStatusText)
   }
 }
 

--- a/core/src/test/scala/fail.scala
+++ b/core/src/test/scala/fail.scala
@@ -26,7 +26,7 @@ with DispatchCleanup {
     Gen.alphaStr.suchThat { _ != "foo"}
   ) { sample =>
     val res = Http(localhost / sample OK as.String).either
-    res() =? Left(StatusCode(404))
+    res() =? Left(StatusCode(404, "Not found"))
   }
 
   property("project left on failure") = forAll(
@@ -35,7 +35,7 @@ with DispatchCleanup {
     val res = Http(localhost / sample OK as.String).either.right.map {
       _ => "error"
     }
-    res() =? Left(StatusCode(404))
+    res() =? Left(StatusCode(404, "Not found"))
   }
 
   property("project right on success2") = {
@@ -59,6 +59,6 @@ with DispatchCleanup {
       res <- Http(localhost / g OK as.String).either.right
       res2 <- Http(localhost / b OK as.String).either.right
     } yield res2
-    eth() =? Left(StatusCode(404))
+    eth() =? Left(StatusCode(404, "Not found"))
   }
 }

--- a/core/src/test/scala/server.scala
+++ b/core/src/test/scala/server.scala
@@ -72,6 +72,6 @@ with DispatchCleanup {
           localhost / "ask" << Map("what" -> sample1,
                                    "echo" -> sample2) OK as.String
         ).either
-        res() ?= Left(StatusCode(500))
+        res() ?= Left(StatusCode(500, "Internal Server Error"))
     }
 }


### PR DESCRIPTION
The human-readable 'reason phrase' in an HTTP response status can contain additional useful diagnostic information - so this change just exposes that message in the StatusCode exception thrown by the OK handler.