### PR TITLE
Spelling fixes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ as its underlying transport. For more info, see the
 
 ### Mailing List
 
-There's a [mailing list for Dispatch][mail]. Please mail the list **before opening 
-github issues** for problems that are not obvious, reproducable bugs.
+There's a [mailing list for Dispatch][mail]. Please mail the list **before opening
+github issues** for problems that are not obvious, reproducible bugs.
 
 [mail]: https://groups.google.com/forum/?fromgroups#!forum/dispatch-scala

--- a/docs/01/00.markdown
+++ b/docs/01/00.markdown
@@ -33,7 +33,7 @@ like this in the output:
     length: dispatch.Promise[Int] = Promise(2)
 
 Both promises depend on the same network operation. By the time the
-second is evealuated by the console, its underlying value may or may
+second is evaluated by the console, its underlying value may or may
 not be available.  But if you try a moment or two later, you'll see
 that both promises print their values.
 

--- a/docs/01/c.markdown
+++ b/docs/01/c.markdown
@@ -38,8 +38,8 @@ available until all the component promises have completed.
 
 ### Implicit ordering
 
-In the body of the for expression we're using `max` on this iterable
-of pairs. Tuples derive thir orderings from their component parts,
+In the body of the for expression we're using `max` on this Iterable
+of pairs. Tuples derive their orderings from their component parts,
 so the max of our tuple `(Int, String)` will be a pair with the
 highest temperature.
 

--- a/docs/02/a.markdown
+++ b/docs/02/a.markdown
@@ -48,7 +48,7 @@ We'll make a slight change to the extraction method.
 def extractTemp(xml: scala.xml.Elem) = {
   val seq = for {
     elem <- xml \\\\ "temp_c"
-    attr <- elem.attribute("data") 
+    attr <- elem.attribute("data")
   } yield attr.toString.toInt
   seq.headOption
 }
@@ -91,7 +91,7 @@ def hottest(locs: String*) = {
 ```
 
 If the nested for-expressions throw you for a loop, keep in mind that
-promises are not themselves iterable. You're dealing with unrelated
+promises are not themselves Iterable. You're dealing with unrelated
 types, even if they share some philosophical opinions. They can't be
 haphazardly mixed in the same for-expression.
 

--- a/docs/02/b.markdown
+++ b/docs/02/b.markdown
@@ -63,7 +63,7 @@ caught. Exceptions are easy to handle when you have a straightforward
 thread of computation. In asynchronous programming, you don't.
 
 Think of exceptions as an ejection seat. They allow you to escape from
-failure without planning ahead. On the downside, somebody's got to
+failure without planning ahead. On the downside, some body's got to
 perform the rescue operation to get you home, which could range in
 difficulty from easy to impossible. With asynchronous callbacks it's
 as if you're flying over enemy territory, or into orbit. The cost and

--- a/docs/02/c.markdown
+++ b/docs/02/c.markdown
@@ -7,7 +7,7 @@ promise to fully control and represent error conditions.
 ### Promise#either
 
 Much like `Promise#option`, the either method returns a promise that
-catches any exception that occurrs in performing the request and
+catches any exception that occurs in performing the request and
 handling its response. But unlike option, either holds on to its
 captured exception.
 
@@ -62,7 +62,7 @@ def extractTemp(xml: scala.xml.Elem):
   Either[String,Int] = {
   val seq = for {
     elem <- xml \\\\ "temp_c"
-    attr <- elem.attribute("data") 
+    attr <- elem.attribute("data")
   } yield attr.toString.toInt
   seq.headOption.toRight {
     "Temperature missing in service response"
@@ -90,7 +90,7 @@ def temperature(loc: String) =
 
 This is fairly similar to the version created with option. You'll
 recall that we can't haphazardly mix promises with other types in for
-expressions, because a promise *is not* an iterable or an
+expressions, because a promise *is not* an Iterable or an
 either. However, if you want to be a little bit fancy you can condense
 these operations by making everything a promise.
 
@@ -152,7 +152,7 @@ def hottest(locs: String*) = {
 ```
 
 This method returns a promise of a 2-tuple, including an option of the
-max and iterable of any errors. With this you can know which city was
+max and Iterable of any errors. With this you can know which city was
 the hottest, as well as which inputs failed and why.
 
 ### Testing the hottest

--- a/docs/04/00.markdown
+++ b/docs/04/00.markdown
@@ -31,8 +31,8 @@ preferred term these days is for-comprehensions.
 ### Break apart complex problems
 
 For non-trivial promise operations, especially when trying to mix with
-iterables, it may be easier to start with the lower level map,
-flatmap, foreach, and many other methods that for-expressions
+Iterables, it may be easier to start with the lower level map,
+flatMap, foreach, and many other methods that for-expressions
 translate into.
 
 Once you get things working with these, you can probably translate it


### PR DESCRIPTION
I noticed that there was some cleanup over in unfiltered, so I ran ispell through the docs for reboot.
