### PR TITLE
Allows the use of an AnyVal when constructing urls with host(...) and forward slash

### DIFF
--- a/core/src/main/scala/requests.scala
+++ b/core/src/main/scala/requests.scala
@@ -54,7 +54,7 @@ trait UrlVerbs extends RequestVerbs {
     subject.setUrl(uri.copy(path=rawPath).toString)
   }
   def / (segment: AnyVal): RequestBuilder = segment match {
-    case unit: Unit => this / ""
+    case unit: Unit => subject
     case other      => this / other.toString
   }
   def secure = {


### PR DESCRIPTION
For example:

``` scala
host("localhost") / "account" / 10
host("localhost") / "set_active" / true
host("localhost") / "x" / 28.3 / "y" / -12 / "z" / 145.235
```
