### PR TITLE
url(String) encodes urls using RawUri(string).toString to encode proper ...

### DIFF
--- a/core/src/main/scala/requests.scala
+++ b/core/src/main/scala/requests.scala
@@ -23,7 +23,7 @@ object host extends HostVerbs
 
 object url extends (String => RequestBuilder) {
   def apply(url: String) = {
-    new RequestBuilder().setUrl(url)
+    new RequestBuilder().setUrl(RawUri(url).toString)
   }
 }
 

--- a/core/src/test/scala/basic.scala
+++ b/core/src/test/scala/basic.scala
@@ -32,6 +32,19 @@ with DispatchCleanup {
   // a shim until we can update scalacheck to a version that non-alpha strings that don't break Java
   val syms = "&#$@%"
 
+  def cyrillicChars = Gen.choose( 0x0400, 0x04FF) map {_.toChar}
+
+  def cyrillic = for {
+      cs <- Gen.listOf(cyrillicChars)
+  } yield {
+      cs.mkString
+  }
+
+  property("url() should encode non-ascii chars in the path") = forAll(cyrillic) { (sample: String) =>
+      val uri = url("http://wikipedia.com/"+sample)
+      uri.build().getUrl() =? RawUri("http://wikipedia.com/"+sample).toString
+  }
+
   property("POST and handle") = forAll(Gen.alphaStr) { (sample: String) =>
     val res = Http(
       localhost / "echo" << Map("echo" -> sample) > as.String


### PR DESCRIPTION
...uri escape sequences for expanded alphabets in uris.

Fixes #40
