### PR TITLE
handle jsoup absolute refs

### DIFF
--- a/jsoup/build.sbt
+++ b/jsoup/build.sbt
@@ -5,4 +5,4 @@ description :=
 
 seq(lsSettings :_*)
 
-libraryDependencies += "org.jsoup" % "jsoup" % "1.6.3"
+libraryDependencies += "org.jsoup" % "jsoup" % "1.7.2"

--- a/jsoup/src/main/scala/as/soup.scala
+++ b/jsoup/src/main/scala/as/soup.scala
@@ -6,7 +6,7 @@ import com.ning.http.client.Response
 
 object Document extends (Response => nodes.Document) {
   def apply(r: Response) =
-    (dispatch.as.String andThen Jsoup.parse)(r)
+    Jsoup.parse(dispatch.as.String(r), r.getUri().toString)
 }
 
 object Query {
@@ -18,5 +18,5 @@ object Query {
 object Clean {
   import org.jsoup.safety.Whitelist
   def apply(wl: Whitelist): Response => String =
-    { r => Jsoup.clean(dispatch.as.String(r), wl) }
+    { r => Jsoup.clean(dispatch.as.String(r), r.getUri().toString, wl) }
 }


### PR DESCRIPTION
call element.absUrl("href") returns nothing since Jsoup parser  doesn't know about original request url
