### PR TITLE
Make duration an optional parameter when applying a Future

### DIFF
--- a/core/src/main/scala/enrich.scala
+++ b/core/src/main/scala/enrich.scala
@@ -52,7 +52,7 @@ class EnrichedFuture[A](underlying: Future[A]) {
     either.map { _.right.toOption }
   }
 
-  def apply() = Await.result(underlying, Duration.Inf)
+  def apply(duration: Duration = Duration.Inf) = Await.result(underlying, duration)
 
   /** Some value if promise is complete, otherwise None */
   def completeOption = 


### PR DESCRIPTION
Applying the value is not the most common way to work with Futures but sometimes just tempting easy :) At least in test code it is ok to just let exceptions bubble up. Still, awaiting for the Future indefinitely is rarely a good idea. I left it as a default to not break code which may depend on that behaviour.
