### PR TITLE
Add operator for setting byte array POST body

### DIFF
--- a/core/src/main/scala/requests.scala
+++ b/core/src/main/scala/requests.scala
@@ -92,6 +92,11 @@ trait ParamVerbs extends RequestVerbs {
         s.addParameter(key, value)
     }
   }
+  /** Set request body to a given byte array, set method to POST
+   * if currently GET. */
+  def << (body: Array[Byte]) = {
+    defaultMethod("POST").setBody(body)
+  }
   /** Set request body to a given string, set method to POST
    * if currently GET. */
   def << (body: String) = {


### PR DESCRIPTION
This was possible in the [classic version](http://www.flotsam.nl/dispatch-periodic-table.html) and as there is a `setBody(body: Array[Byte])` available, it only makes sense to add this here as well.
