### PR TITLE
provide interface that exposes ahc's interface for decoding the str response

### DIFF
--- a/core/src/main/scala/as/core.scala
+++ b/core/src/main/scala/as/core.scala
@@ -10,7 +10,8 @@ object Response {
 }
 
 object String extends (client.Response => String) {
-  /** @return response body as a ISO-8859-1 decoded string */
+  /** @return response body as a string decoded as either the charset provided by
+   *  Content-Type header of the response or ISO-8859-1 */
   def apply(r: client.Response) = r.getResponseBody
 
   /** @return a function that will return response body decoded in the provided charset */


### PR DESCRIPTION
The `as.String` response handling function will currently return the request body string decoded with [the default charset](https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-1.8.1/src/main/java/com/ning/http/client/providers/netty/NettyResponse.java#L87-L89) defined in the netty provider, [ISO-8859-1](https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-1.8.1/src/main/java/com/ning/http/client/providers/netty/NettyResponse.java#L87-L89). ACH does however  provide an interface for [decoding the response in a specified charset](https://github.com/AsyncHttpClient/async-http-client/blob/async-http-client-1.8.1/src/main/java/com/ning/http/client/providers/netty/NettyResponse.java#L91-L93).

This change set exposes that interface in dispatches `as.String` module by adding `as.String.charset(java.nio.charset.Charset)` and for convenience, `as.String.utf8` for common modern day response encodings. 
