### PR TITLE
Change key in emptyToken to null so it can be used to request access token

### DIFF
--- a/core/src/main/scala/oauth/requests.scala
+++ b/core/src/main/scala/oauth/requests.scala
@@ -5,7 +5,7 @@ import com.ning.http.client.oauth._
 import dispatch._
 
 class SigningVerbs(val subject: Req) extends RequestVerbs {
-  val emptyToken = new RequestToken("", "")
+  val emptyToken = new RequestToken(null, "")
 
   def sign(consumer: ConsumerKey, token: RequestToken = emptyToken) = {
     val calc = new OAuthSignatureCalculator(consumer, token)


### PR DESCRIPTION
I got error when requesting access token using Dispatch. It because if I sign request only using ConsumerKey, request header still contains oauth_token="". The solution is to set key in emptyToken to null. See https://github.com/AsyncHttpClient/async-http-client/pull/504.
