### PR TITLE
Lift 2.6 bump

### DIFF
--- a/liftjson/build.sbt
+++ b/liftjson/build.sbt
@@ -10,11 +10,9 @@ seq(lsSettings :_*)
 libraryDependencies ++= Seq(
   "net.liftweb" %% "lift-json" % "2.6" cross CrossVersion.binaryMapped {
     // Makes update resolution happy, but since w'ere not building for 2.9.3
-    // we won't end up in runtime version hell by doing this. This is needed
-    // because of unfiltered-json's build definition. Changing that may allow
-    // this to go away.
+    // we won't end up in runtime version hell by doing this.
     case "2.9.3" => "2.9.1"
     case x => x
   },
-  "net.databinder" %% "unfiltered-json" % "0.6.7" % "test"
+  "org.mockito" % "mockito-core" % "1.10.19" % "test"
 )

--- a/liftjson/build.sbt
+++ b/liftjson/build.sbt
@@ -8,7 +8,7 @@ seq(lsSettings :_*)
 libraryDependencies <++= scalaVersion( sv =>
   Seq(sv.split("[.-]").toList match {
     case "2" :: "9" :: _ =>
-      "net.liftweb" % "lift-json_2.9.2" % "2.5-RC6"
-    case _ => "net.liftweb" %% "lift-json" % "2.5-RC6"
+      "net.liftweb" % "lift-json_2.9.2" % "2.6"
+    case _ => "net.liftweb" %% "lift-json" % "2.6"
   }, "net.databinder" %% "unfiltered-json" % "0.6.7" % "test")
 )

--- a/liftjson/build.sbt
+++ b/liftjson/build.sbt
@@ -5,10 +5,16 @@ description :=
 
 seq(lsSettings :_*)
 
-libraryDependencies <++= scalaVersion( sv =>
-  Seq(sv.split("[.-]").toList match {
-    case "2" :: "9" :: _ =>
-      "net.liftweb" % "lift-json_2.9.2" % "2.6"
-    case _ => "net.liftweb" %% "lift-json" % "2.6"
-  }, "net.databinder" %% "unfiltered-json" % "0.6.7" % "test")
+(skip in compile) <<= scalaVersion { sv => () => sv == "2.9.3" }
+
+libraryDependencies ++= Seq(
+  "net.liftweb" %% "lift-json" % "2.6" cross CrossVersion.binaryMapped {
+    // Makes update resolution happy, but since w'ere not building for 2.9.3
+    // we won't end up in runtime version hell by doing this. This is needed
+    // because of unfiltered-json's build definition. Changing that may allow
+    // this to go away.
+    case "2.9.3" => "2.9.1"
+    case x => x
+  },
+  "net.databinder" %% "unfiltered-json" % "0.6.7" % "test"
 )

--- a/liftjson/build.sbt
+++ b/liftjson/build.sbt
@@ -7,6 +7,8 @@ seq(lsSettings :_*)
 
 (skip in compile) <<= scalaVersion { sv => () => sv == "2.9.3" }
 
+publishArtifact <<= scalaVersion { sv => sv != "2.9.3" }
+
 libraryDependencies ++= Seq(
   "net.liftweb" %% "lift-json" % "2.6" cross CrossVersion.binaryMapped {
     // Makes update resolution happy, but since w'ere not building for 2.9.3

--- a/project/build.scala
+++ b/project/build.scala
@@ -10,8 +10,14 @@ object Builds extends sbt.Build {
         ls.Plugin.LsKeys.skipWrite := true,
       publish := { }
       )
-    ).aggregate(core, jsoup, tagsoup, liftjson,
-      json4sJackson, json4sNative)
+    ).aggregate(
+      core,
+      jsoup,
+      tagsoup,
+      liftjson,
+      json4sJackson,
+      json4sNative
+    )
 
   def module(name: String, settings: Seq[Def.Setting[_]] = Seq.empty) =
     Project(name,

--- a/project/build.scala
+++ b/project/build.scala
@@ -10,7 +10,7 @@ object Builds extends sbt.Build {
         ls.Plugin.LsKeys.skipWrite := true,
       publish := { }
       )
-    ).aggregate(core, jsoup, tagsoup, // liftjson - no 2.11 artifact
+    ).aggregate(core, jsoup, tagsoup, liftjson,
       json4sJackson, json4sNative)
 
   def module(name: String, settings: Seq[Def.Setting[_]] = Seq.empty) =


### PR DESCRIPTION
As requested from ticket #92, this PR bumps dispatch's lift-json dependency to the 2.6 Final which was released today. It looks like some tweaking may be needed for the unfiltered dependency and I'll need someone else to verify things still compile under 2.9.x. My local install of sbt doesn't seem to allow you to get away with the 2.9 configuration we're using here:

```
[error] Modules were resolved with conflicting cross-version suffixes in {file:/Users/matt/Projects/reboot/}lift-json:
[error]    net.liftweb:lift-json _2.9.2, _2.9.1
```

What was the reasoning behind that, again?

That said, depending on 2.6 final should allow you guys to start building liftjson as a part of your regular release cycle again.

Cheers!