### PR TITLE
Fix formDecode for empty parameter values.

### DIFF
--- a/core/src/main/scala/as/oauth/token.scala
+++ b/core/src/main/scala/as/oauth/token.scala
@@ -12,6 +12,7 @@ object Token extends (Response => Either[String, RequestToken]) {
       yield pair.split('=')
     ).collect {
       case Array(key, value) => decode(key) -> decode(value)
+      case Array(key) => decode(key) -> ""
     }
 
   private def tokenDecode(str: String) = {


### PR DESCRIPTION
formDecode() ignores empty parameter values. This leads to a "No token found in response" error in tokenDecode() if "oauth_token_secret" is empty.

Evernote for example does not provide an oauth_token_secret:
`oauth_token=S%3Ds4%3AU%3Da1%3AE%3D12bfd68c6b6%3AC%3D12bf8426ab8%3AP%3D7%3AA%3Den_oauth_test%3AH%3D3df9cf6c0d7bc410824c80231e64dbe1&oauth_token_secret=&edam_noteStoreUrl=https%3A%2F%2Fsandbox.evernote.com%2Fedam%2Fnote%2Fshard%2Fs4&edam_userId=161`
(https://dev.evernote.com/doc/articles/authentication.php)

