### PR TITLE
async-http-client-1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ language: scala
 scala:
   - 2.10.4
 jdk:
-  - openjdk6
+  - openjdk7

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,7 +4,7 @@ description :=
   "Core Dispatch module wrapping sonatype/async-http-client"
 
 libraryDependencies +=
-  "com.ning" % "async-http-client" % "1.8.10"
+  "com.ning" % "async-http-client" % "1.9.11"
 
 Seq(lsSettings :_*)
 

--- a/core/src/main/scala/defaults.scala
+++ b/core/src/main/scala/defaults.scala
@@ -1,6 +1,5 @@
 package dispatch
 
-import scala.concurrent.duration.Duration
 import org.jboss.netty.util.{Timer, HashedWheelTimer}
 import org.jboss.netty.channel.socket.nio.{
   NioClientSocketChannelFactory, NioWorkerPool}
@@ -42,7 +41,7 @@ private [dispatch] object InternalDefaults {
     lazy val timer = new HashedWheelTimer()
     def builder = new AsyncHttpClientConfig.Builder()
       .setUserAgent("Dispatch/%s" format BuildInfo.version)
-      .setRequestTimeoutInMs(-1) // don't timeout streaming connections
+      .setRequestTimeout(-1) // don't timeout streaming connections
   }
 
   /** Uses daemon threads and tries to exit cleanly when running in sbt  */
@@ -83,7 +82,7 @@ private [dispatch] object InternalDefaults {
       }
 
       val config = new NettyAsyncHttpProviderConfig().addProperty(
-        NettyAsyncHttpProviderConfig.SOCKET_CHANNEL_FACTORY,
+        "socketChannelFactory",
         nioClientSocketChannelFactory
       )
       config.setNettyTimer(timer)

--- a/core/src/main/scala/oauth/exchange.scala
+++ b/core/src/main/scala/oauth/exchange.scala
@@ -1,9 +1,13 @@
 package dispatch.oauth
 
+import java.util
+
+import com.ning.http.client.Param
 import dispatch._
 
 import scala.concurrent.{Future,ExecutionContext}
 import com.ning.http.client.oauth._
+import com.ning.http.client.uri.Uri
 
 trait SomeHttp {
   def http: HttpExecutor
@@ -54,17 +58,16 @@ trait Exchange {
   }
 
   def signedAuthorize(reqToken: RequestToken) = {
-    import com.ning.http.client.FluentStringsMap
 
     val calc = new OAuthSignatureCalculator(consumer, reqToken)
     val timestamp = System.currentTimeMillis() / 1000L
     val unsigned = url(authorize) <<? Map("oauth_token" -> reqToken.getKey)
     val sig = calc.calculateSignature("GET",
-                                      unsigned.url,
+                                      Uri.create(unsigned.url),
                                       timestamp,
                                       generateNonce,
-                                      new FluentStringsMap,
-                                      new FluentStringsMap)
+                                      new util.ArrayList[Param](),
+                                      new util.ArrayList[Param]())
     (unsigned <<? Map("oauth_signature" -> sig)).url
   }
 

--- a/core/src/main/scala/oauth/requests.scala
+++ b/core/src/main/scala/oauth/requests.scala
@@ -10,9 +10,7 @@ class SigningVerbs(val subject: Req) extends RequestVerbs {
   def sign(consumer: ConsumerKey, token: RequestToken = emptyToken) = {
     val calc = new OAuthSignatureCalculator(consumer, token)
     subject underlying { r =>
-      val req = r.build
-      val baseurl = req.getUrl().takeWhile { _ != '?' }.mkString("")
-      calc.calculateAndAddSignature(baseurl, req, r)
+      calc.calculateAndAddSignature(r.build, r)
       r
     }
   }

--- a/core/src/main/scala/requests.scala
+++ b/core/src/main/scala/requests.scala
@@ -1,6 +1,7 @@
 package dispatch
 
-import com.ning.http.client.RequestBuilder
+import com.ning.http.client.{FluentStringsMap, BodyGenerator, RequestBuilder}
+import com.ning.http.client.multipart.Part
 
 /** This wrapper provides referential transparency for the
   underlying RequestBuilder. */
@@ -153,9 +154,8 @@ trait AuthVerbs extends RequestVerbs {
 }
 
 trait RequestBuilderVerbs extends RequestVerbs {
-  import com.ning.http.client.{ FluentStringsMap, Part, ProxyServer, Realm, Request }
+  import com.ning.http.client.{ ProxyServer, Realm }
   import com.ning.http.client.cookie.Cookie
-  import Request.EntityWriter
   import scala.collection.JavaConverters._
   import java.util.Collection
 
@@ -166,18 +166,18 @@ trait RequestBuilderVerbs extends RequestVerbs {
   def addHeader(name: String, value: String) =
     subject.underlying { _.addHeader(name, value) }
   def addParameter(key: String, value: String) =
-    subject.underlying { _.addParameter(key, value) }
+    subject.underlying { _.addFormParam(key, value) }
   def addQueryParameter(name: String, value: String) =
-    subject.underlying { _.addQueryParameter(name, value) }
+    subject.underlying { _.addQueryParam(name, value) }
   def setQueryParameters(params: Map[String, Seq[String]]) =
-    subject.underlying { _.setQueryParameters(new FluentStringsMap(
+    subject.underlying { _.setQueryParams(new FluentStringsMap(
       params.mapValues{ _.asJava: Collection[String] }.asJava
     )) }
   def setBody(data: Array[Byte]) =
     subject.underlying(rb => rb.setBody(data), p => p.copy(bodyType = Req.ByteArrayBody))
-  def setBody(dataWriter: EntityWriter, length: Long) =
-    subject.underlying(rb => rb.setBody(dataWriter, length), p => p.copy(bodyType = Req.EntityWriterBody))
-  def setBody(dataWriter: EntityWriter) =
+  def setBody(dataWriter: BodyGenerator, length: Long) =
+    subject.underlying(rb => rb.setBody(dataWriter), p => p.copy(bodyType = Req.EntityWriterBody))
+  def setBody(dataWriter: BodyGenerator) =
     subject.underlying(rb => rb.setBody(dataWriter), p => p.copy(bodyType = Req.EntityWriterBody))
   def setBody(data: String) =
     subject.underlying(rb => rb.setBody(data), p => p.copy(bodyType = Req.StringBody))
@@ -197,8 +197,8 @@ trait RequestBuilderVerbs extends RequestVerbs {
       headers.mapValues { _.asJava: Collection[String] }.asJava
     ) }
   def setParameters(parameters: Map[String, Seq[String]]) =
-    subject.underlying { _.setParameters(
-      parameters.mapValues { _.asJava: Collection[String] }.asJava
+    subject.underlying { _.setFormParams(
+      parameters.mapValues { _.asJava: java.util.List[String] }.asJava
     ) }
   def setMethod(method: String) =
     subject.underlying { _.setMethod(method) }

--- a/json4sjackson/build.sbt
+++ b/json4sjackson/build.sbt
@@ -6,7 +6,7 @@ description :=
 Seq(lsSettings :_*)
 
 libraryDependencies ++= Seq(
-  "org.json4s" %% "json4s-jackson" % "3.2.10",
-  "net.databinder" %% "unfiltered-netty" % "0.8.0" % "test"
+  "org.json4s" %% "json4s-jackson" % "3.2.11",
+  "net.databinder" %% "unfiltered-netty" % "0.8.4" % "test"
 )
 

--- a/json4snative/build.sbt
+++ b/json4snative/build.sbt
@@ -6,8 +6,8 @@ description :=
 Seq(lsSettings :_*)
 
 libraryDependencies ++= Seq(
-  "org.json4s" %% "json4s-core" % "3.2.10",
-  "org.json4s" %% "json4s-native" % "3.2.10",
-  "net.databinder" %% "unfiltered-netty" % "0.8.0" % "test"
+  "org.json4s" %% "json4s-core" % "3.2.11",
+  "org.json4s" %% "json4s-native" % "3.2.11",
+  "net.databinder" %% "unfiltered-netty" % "0.8.4" % "test"
 )
 

--- a/jsoup/build.sbt
+++ b/jsoup/build.sbt
@@ -5,4 +5,4 @@ description :=
 
 seq(lsSettings :_*)
 
-libraryDependencies += "org.jsoup" % "jsoup" % "1.7.3"
+libraryDependencies += "org.jsoup" % "jsoup" % "1.8.1"

--- a/jsoup/src/test/scala/soup.scala
+++ b/jsoup/src/test/scala/soup.scala
@@ -40,14 +40,14 @@ with DispatchCleanup {
     val doc = Http(
       localhost / "echo" <<? Map("echo" -> sample) > as.jsoup.Document
     )  
-    doc().select("div#echo").first().text() == (sample)
+    doc().select("div#echo").first().text() == sample
   }
 
   property("handle Queries") = forAll(Gen.alphaStr) { (sample: String) =>
     val els = Http(
       localhost / "echo" <<? Map("echo" -> sample) > as.jsoup.Query("div")
     )
-    els().first().text() == (sample)
+    els().first().text() == sample
   }
 
   property("handle Cleaning") = forAll(Gen.alphaStr) { (sample: String) =>
@@ -62,6 +62,6 @@ with DispatchCleanup {
     val doc = Http(
       localhost / "relative" <<? Map("echo" -> sample) > as.jsoup.Document
     )
-    doc().select("a").first().absUrl("href") == (localhost.url + "/category")
+    doc().select("a").first().absUrl("href") == (localhost.url + "category")
   }
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.5

--- a/project/common.scala
+++ b/project/common.scala
@@ -15,7 +15,7 @@ object Common {
   val settings: Seq[Setting[_]] = ls.Plugin.lsSettings ++ Seq(
     version := "0.11.2",
 
-    crossScalaVersions := Seq("2.9.3", "2.10.4", "2.11.2"),
+    crossScalaVersions := Seq("2.9.3", "2.10.4", "2.11.5"),
 
     scalaVersion := defaultScalaVersion,
 


### PR DESCRIPTION
This PR upgrades the project to use async-http-client-1.9.x.

Things to inspect:
- ```NettyAsyncHttpProviderConfig.SOCKET_CHANNEL_FACTORY``` is not present anymore
- ```EntityWriter``` as been completely replaced by ```BodyGenerator```
- I had to modified the jsoupSpec as ```localhost.url``` now ends with ```/```

I also upgraded a few other dependencies on the way :bowtie:

