### PR TITLE
Include logging dependency in documentation

### DIFF
--- a/docs/00.markdown
+++ b/docs/00.markdown
@@ -20,7 +20,10 @@ shell and change to an empty or unimportant directory, then paste:
 [sbt]: https://github.com/harrah/xsbt/wiki/
 
     echo 'libraryDependencies += 
-      "net.databinder.dispatch" %% "dispatch-core" % "$version$"' > build.sbt
+      "net.databinder.dispatch" %% "dispatch-core" % "$version$"
+      
+      libraryDependencies += 
+      "ch.qos.logback" % "logback-classic" % "1.1.2"' > build.sbt
     sbt console
 
 After "the internet" has downloaded, you're good to go.


### PR DESCRIPTION
By default, attempting to run the sample application throws the following error:

```scala
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

This allows us to provide a fix for users who are new to the library.

See Issues #106 / #90 for an example of this occurring.