### PR TITLE
Close old client reference on configure

### DIFF
--- a/core/src/main/scala/execution.scala
+++ b/core/src/main/scala/execution.scala
@@ -17,6 +17,7 @@ case class Http(
   /** Replaces `client` with a new instance configured using the withBuilder
       function. The current client config is the builder's prototype.  */
   def configure(withBuilder: Builder => Builder) =
+    shutdown()
     copy(client =
       new AsyncHttpClient(withBuilder(
         new AsyncHttpClientConfig.Builder(client.getConfig)


### PR DESCRIPTION
I think the logic around configure should be changed. There is no reason to create a default instance until configure is called.

Anyhow, this should do the trick and not break the API.
