### PR TITLE
Bump async-http-client to 1.9.30

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,7 +4,7 @@ description :=
   "Core Dispatch module wrapping sonatype/async-http-client"
 
 libraryDependencies +=
-  "com.ning" % "async-http-client" % "1.9.11"
+  "com.ning" % "async-http-client" % "1.9.30"
 
 Seq(lsSettings :_*)
 


### PR DESCRIPTION
Hey @n8han! 

I'm on a spree of updating dependency versions and noticed this. I ran tests and nothing broke -- so that's good! 
