### PR TITLE
Instantiate the AsyncHttpClient lazily

### DIFF
--- a/core/src/main/scala/defaults.scala
+++ b/core/src/main/scala/defaults.scala
@@ -28,7 +28,7 @@ private [dispatch] object InternalDefaults {
     if (inSbt) SbtProcessDefaults
     else BasicDefaults
 
-  def client = new AsyncHttpClient(underlying.builder.build())
+  lazy val builder = underlying.builder
   lazy val timer = underlying.timer
 
   private trait Defaults {

--- a/core/src/main/scala/execution.scala
+++ b/core/src/main/scala/execution.scala
@@ -10,24 +10,24 @@ import scala.concurrent.{ExecutionContext}
 
 /** Http executor with defaults */
 case class Http(
-  client: AsyncHttpClient = InternalDefaults.client
+  builder: AsyncHttpClientConfig.Builder = InternalDefaults.builder
 ) extends HttpExecutor {
   import AsyncHttpClientConfig.Builder
 
-  /** Replaces `client` with a new instance configured using the withBuilder
+  lazy val client = new AsyncHttpClient(builder.build)
+
+  /** Replaces `builder` with a new config built using the withBuilder
       function. The current client config is the builder's prototype.  */
-  def configure(withBuilder: Builder => Builder) =
-    copy(client =
-      new AsyncHttpClient(withBuilder(
-        new AsyncHttpClientConfig.Builder(client.getConfig)
-      ).build)
-    )
+  def configure(withBuilder: Builder => Builder) = {
+    val newBuilder = new Builder(this.builder.build)
+    copy(builder = withBuilder(newBuilder))
+  }
 }
 
 /** Singleton default Http executor, can be used directly or altered
  *  with its case-class `copy` */
 object Http extends Http(
-  InternalDefaults.client
+  InternalDefaults.builder
 )
 
 trait HttpExecutor { self =>


### PR DESCRIPTION
This is to fix the resource leak caused by creating a new client in
`configure` and not shutting down the old one.

Instantiating a singleton client was a problem because (by definition of
being a singleton) it might be shared between multiple `Http` instances,
meaning it's hard to know when you can/should shut it down.

Got around the problem by making `Http` hold a config builder and a
`lazy val client`.

It's still possible to leak an `AsyncHttpClient` instance by making
requests and then calling `configure` later, but I think people are less
likely to do that. The normal use case is to configure your client at
application startup and then start making requests.
