### PR TITLE
Set useProxyProperties true as the default setting

### DIFF
--- a/core/src/main/scala/defaults.scala
+++ b/core/src/main/scala/defaults.scala
@@ -42,6 +42,7 @@ private [dispatch] object InternalDefaults {
     def builder = new AsyncHttpClientConfig.Builder()
       .setUserAgent("Dispatch/%s" format BuildInfo.version)
       .setRequestTimeout(-1) // don't timeout streaming connections
+      .setUseProxyProperties(true)
   }
 
   /** Uses daemon threads and tries to exit cleanly when running in sbt  */


### PR DESCRIPTION
We can not use proxies with a client created by Http.configure although we call `setUseProxyProperties(true)` in [withBuilder](https://github.com/dispatch/reboot/blob/master/core/src/main/scala/execution.scala#L19), because [proxyServerSelector](https://github.com/AsyncHttpClient/async-http-client/blob/1.9.x/src/main/java/com/ning/http/client/AsyncHttpClientConfig.java#L996-L1000) already has an instance of ProxyServerSelector (i.e. proxyServerSelector isn't null).

Close #122
