### PR TITLE
Don't build multiple times from the same builder

### DIFF
--- a/core/src/main/scala/requests.scala
+++ b/core/src/main/scala/requests.scala
@@ -17,7 +17,7 @@ with AuthVerbs with HeaderVerbs with RequestBuilderVerbs {
     Req(run andThen nextReq, nextProps(props))
 
   def toRequestBuilder = {
-    val requestBuilder = run(new RequestBuilder)
+    def requestBuilder = run(new RequestBuilder)
     //Body set from String and with no Content-Type will get a default of 'text/plain; charset=UTF-8'
     if(props.bodyType == Req.StringBody && !requestBuilder.build.getHeaders.containsKey("Content-Type")) {
       setContentType("text/plain", "UTF-8").run(new RequestBuilder)

--- a/core/src/test/scala/basic.scala
+++ b/core/src/test/scala/basic.scala
@@ -22,6 +22,9 @@ with DispatchCleanup {
         PlainTextContent ~> ResponseString(req.method)
       case req @ Path(Seg("echobody" :: Nil)) =>
         PlainTextContent ~> ResponseString(req.method + Body.string(req))
+      case req @ Path(Seg("echoquery" :: Nil)) & QueryParams(queryParams) =>
+        val params = queryParams.flatMap { case (k, vs) => vs.map(v => k + "=" + v) }.mkString("&")
+        PlainTextContent ~> ResponseString(req.method + params)
       case Path(Seg("agent" :: Nil)) & UserAgent(agent) =>
         PlainTextContent ~> ResponseString(agent)
       case Path(Seg("contenttype" :: Nil)) & RequestContentType(contenttype) =>
@@ -62,6 +65,16 @@ with DispatchCleanup {
       localhost / "echo" << Map("echo" -> sample) > as.String
     )
     res() ?= ("POST" + sample)
+  }
+
+  property("POST json with query params") = forAll(Gen.alphaStr) { (value: String) =>
+    val headers = Map("Content-Type" -> "application/json")
+    val params = Map("key" -> value)
+    val body = """{"foo":"bar"}"""
+    val res = Http(
+      localhost / "echoquery" <:< headers <<? params << body OK  as.String
+    )
+    res() ?= ("POST" + "key=" + value)
   }
 
   property("POST non-ascii chars body and get response") = forAll(cyrillic) { (sample: String) =>


### PR DESCRIPTION
Doing so leads to query parameters appearing multiple times in the resulting URL (once for each build call).
