### PR TITLE
Switch to AsyncHttpClient 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 before_script:
  - "echo $JAVA_OPTS"
- - "export JAVA_OPTS='-Xmx512m -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M'"
+ - "export JAVA_OPTS='-Xmx512m -Xss1M -XX:+CMSClassUnloadingEnabled'"
 language: scala
 scala:
-  - 2.9.3
+  - 2.10.4
+  - 2.11.2
 jdk:
-  - openjdk7
+  - oraclejdk8

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,7 +4,7 @@ description :=
   "Core Dispatch module wrapping sonatype/async-http-client"
 
 libraryDependencies +=
-  "org.asynchttpclient" % "async-http-client" % "2.0.0"
+  "org.asynchttpclient" % "async-http-client" % "2.0.2"
 
 Seq(lsSettings :_*)
 

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,7 +4,7 @@ description :=
   "Core Dispatch module wrapping sonatype/async-http-client"
 
 libraryDependencies +=
-  "org.asynchttpclient" % "async-http-client" % "2.0.0-RC21"
+  "org.asynchttpclient" % "async-http-client" % "2.0.0"
 
 Seq(lsSettings :_*)
 

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,7 +4,7 @@ description :=
   "Core Dispatch module wrapping sonatype/async-http-client"
 
 libraryDependencies +=
-  "com.ning" % "async-http-client" % "1.9.11"
+  "org.asynchttpclient" % "async-http-client" % "2.0.0-RC21"
 
 Seq(lsSettings :_*)
 

--- a/core/src/main/scala/as/core.scala
+++ b/core/src/main/scala/as/core.scala
@@ -2,36 +2,36 @@ package dispatch.as
 
 import dispatch._
 
-import com.ning.http.client
 import java.nio.charset.Charset
+import org.asynchttpclient
 
 object Response {
-  def apply[T](f: client.Response => T) = f
+  def apply[T](f: asynchttpclient.Response => T) = f
 }
 
-object String extends (client.Response => String) {
+object String extends (asynchttpclient.Response => String) {
   /** @return response body as a string decoded as either the charset provided by
    *  Content-Type header of the response or ISO-8859-1 */
-  def apply(r: client.Response) = r.getResponseBody
+  def apply(r: asynchttpclient.Response) = r.getResponseBody
 
   /** @return a function that will return response body decoded in the provided charset */
-  case class charset(set: Charset) extends (client.Response => String) {
-    def apply(r: client.Response) = r.getResponseBody(set.name)
+  case class charset(set: Charset) extends (asynchttpclient.Response => String) {
+    def apply(r: asynchttpclient.Response) = r.getResponseBody(set)
   }
 
   /** @return a function that will return response body as a utf8 decoded string */
   object utf8 extends charset(Charset.forName("utf8"))
 }
 
-object Bytes extends (client.Response => Array[Byte]) {
-  def apply(r: client.Response) = r.getResponseBodyAsBytes
+object Bytes extends (asynchttpclient.Response => Array[Byte]) {
+  def apply(r: asynchttpclient.Response) = r.getResponseBodyAsBytes
 }
 
 object File extends {
   def apply(file: java.io.File) =
-    (new client.resumable.ResumableAsyncHandler with OkHandler[Nothing])
+    (new asynchttpclient.handler.resumable.ResumableAsyncHandler with OkHandler[asynchttpclient.Response])
       .setResumableListener(
-        new client.extra.ResumableRandomAccessFileListener(
+        new asynchttpclient.handler.resumable.ResumableRandomAccessFileListener(
           new java.io.RandomAccessFile(file, "rw")
         )
       )

--- a/core/src/main/scala/as/oauth/token.scala
+++ b/core/src/main/scala/as/oauth/token.scala
@@ -1,8 +1,7 @@
 package dispatch.as.oauth
 
-import dispatch.oauth._
-import com.ning.http.client.Response
-import com.ning.http.client.oauth._
+import org.asynchttpclient.Response
+import org.asynchttpclient.oauth.RequestToken
 
 object Token extends (Response => Either[String, RequestToken]) {
   def apply(res: Response) = tokenDecode(dispatch.as.String(res))

--- a/core/src/main/scala/as/stream/lines.scala
+++ b/core/src/main/scala/as/stream/lines.scala
@@ -2,8 +2,6 @@ package dispatch.as.stream
 
 import dispatch._
 
-import com.ning.http.client._
-
 object Lines {
   def apply[U](f: String => U) =
     new stream.StringsByLine[Unit] {

--- a/core/src/main/scala/defaults.scala
+++ b/core/src/main/scala/defaults.scala
@@ -1,13 +1,7 @@
 package dispatch
 
-import org.jboss.netty.util.{Timer, HashedWheelTimer}
-import org.jboss.netty.channel.socket.nio.{
-  NioClientSocketChannelFactory, NioWorkerPool}
-import java.util.{concurrent => juc}
-import com.ning.http.client.{
-  AsyncHttpClient, AsyncHttpClientConfig
-}
-import com.ning.http.client.providers.netty.NettyAsyncHttpProviderConfig
+import io.netty.util.{Timer, HashedWheelTimer}
+import org.asynchttpclient._
 
 object Defaults {
   implicit def executor = scala.concurrent.ExecutionContext.Implicits.global
@@ -15,92 +9,22 @@ object Defaults {
 }
 
 private [dispatch] object InternalDefaults {
-  /** true if we think we're runing un-forked in an sbt-interactive session */
-  val inSbt = (
-    for (group <- Option(Thread.currentThread.getThreadGroup))
-    yield (
-      group.getName == "trap.exit" // sbt version <= 0.13.0
-      || group.getName.startsWith("run-main-group") // sbt 0.13.1+
-    )
-  ).getOrElse(false)
+  private lazy val underlying = BasicDefaults
 
-  private lazy val underlying = 
-    if (inSbt) SbtProcessDefaults
-    else BasicDefaults
-
-  def client = new AsyncHttpClient(underlying.builder.build())
+  lazy val config = underlying.builder.build()
+  def client = new DefaultAsyncHttpClient(config)
   lazy val timer = underlying.timer
 
   private trait Defaults {
-    def builder: AsyncHttpClientConfig.Builder
+    def builder: DefaultAsyncHttpClientConfig.Builder
     def timer: Timer
   }
 
   /** Sets a user agent, no timeout for requests  */
   private object BasicDefaults extends Defaults {
     lazy val timer = new HashedWheelTimer()
-    def builder = new AsyncHttpClientConfig.Builder()
+    def builder = new DefaultAsyncHttpClientConfig.Builder()
       .setUserAgent("Dispatch/%s" format BuildInfo.version)
       .setRequestTimeout(-1) // don't timeout streaming connections
   }
-
-  /** Uses daemon threads and tries to exit cleanly when running in sbt  */
-  private object SbtProcessDefaults extends Defaults {
-    def builder = {
-      val shuttingDown = new juc.atomic.AtomicBoolean(false)
-
-      def shutdown() {
-        if (shuttingDown.compareAndSet(false, true)) {
-          nioClientSocketChannelFactory.releaseExternalResources()
-          timer.stop()
-        }
-      }
-      /** daemon threads that also shut down everything when interrupted! */
-      lazy val interruptThreadFactory = new juc.ThreadFactory {
-        def newThread(runnable: Runnable) = {
-          new Thread(runnable) {
-            setDaemon(true)
-            /** only reliably called on any thread if all spawned threads are daemon */
-            override def interrupt() {
-              shutdown()
-              super.interrupt()
-            }
-          }
-        }
-      }
-      lazy val nioClientSocketChannelFactory = {
-        val workerCount = 2 * Runtime.getRuntime().availableProcessors()
-        new NioClientSocketChannelFactory(
-          juc.Executors.newCachedThreadPool(interruptThreadFactory),
-          1,
-          new NioWorkerPool(
-            juc.Executors.newCachedThreadPool(interruptThreadFactory),
-            workerCount
-          ),
-          timer
-        )
-      }
-
-      val config = new NettyAsyncHttpProviderConfig().addProperty(
-        "socketChannelFactory",
-        nioClientSocketChannelFactory
-      )
-      config.setNettyTimer(timer)
-      BasicDefaults.builder.setAsyncHttpClientProviderConfig(config)
-    }
-    lazy val timer = new HashedWheelTimer(DaemonThreads.factory)
-  }
-}
-
-object DaemonThreads {
-  /** produces daemon threads that won't block JVM shutdown */
-  val factory = new juc.ThreadFactory {
-    def newThread(runnable: Runnable): Thread ={
-      val thread = new Thread(runnable)
-      thread.setDaemon(true)
-      thread
-    }
-  }
-  def apply(threadPoolSize: Int) =
-    juc.Executors.newFixedThreadPool(threadPoolSize, factory)
 }

--- a/core/src/main/scala/enrich.scala
+++ b/core/src/main/scala/enrich.scala
@@ -1,11 +1,7 @@
 package dispatch
 
-import com.ning.http.client.ListenableFuture
-import java.util.{concurrent => juc}
-import juc.TimeUnit
 import scala.concurrent.{ExecutionContext,Await,ExecutionException}
 import scala.concurrent.duration.Duration
-import scala.util.control.Exception.{allCatch,catching}
 
 class EnrichedFuture[A](underlying: Future[A]) {
 

--- a/core/src/main/scala/handlers.scala
+++ b/core/src/main/scala/handlers.scala
@@ -1,7 +1,6 @@
 package dispatch
 
-import com.ning.http.client
-import client.{
+import org.asynchttpclient.{
   Response, AsyncCompletionHandler, AsyncHandler,
   HttpResponseStatus
 }

--- a/core/src/main/scala/oauth/exchange.scala
+++ b/core/src/main/scala/oauth/exchange.scala
@@ -2,12 +2,13 @@ package dispatch.oauth
 
 import java.util
 
-import com.ning.http.client.Param
 import dispatch._
+import org.asynchttpclient._
+import org.asynchttpclient.oauth._
+import org.asynchttpclient.uri.Uri
+import org.asynchttpclient.util.Base64
 
-import scala.concurrent.{Future,ExecutionContext}
-import com.ning.http.client.oauth._
-import com.ning.http.client.uri.Uri
+import scala.concurrent.{ExecutionContext, Future}
 
 trait SomeHttp {
   def http: HttpExecutor
@@ -38,7 +39,7 @@ trait Exchange {
 
   def generateNonce = nonceBuffer.synchronized {
     random.nextBytes(nonceBuffer)
-    com.ning.http.util.Base64.encode(nonceBuffer)
+    Base64.encode(nonceBuffer)
   }
 
   def message[A](promised: Future[A], ctx: String)

--- a/core/src/main/scala/oauth/requests.scala
+++ b/core/src/main/scala/oauth/requests.scala
@@ -1,8 +1,7 @@
 package dispatch.oauth
 
-import com.ning.http.client.oauth._
-
 import dispatch._
+import org.asynchttpclient.oauth._
 
 class SigningVerbs(val subject: Req) extends RequestVerbs {
   val emptyToken = new RequestToken(null, "")

--- a/core/src/main/scala/package.scala
+++ b/core/src/main/scala/package.scala
@@ -1,14 +1,8 @@
-import com.ning.http.client.RequestBuilder
-
 package object dispatch {
   /** Type alias for Response, avoid need to import */
-  type Res = com.ning.http.client.Response
+  type Res = org.asynchttpclient.Response
   /** Type alias for URI, avoid need to import */
   type Uri = java.net.URI
-
-  @deprecated("Use `RequestBuilder.underlying` to preserve referential transparency",
-    since="0.11.0")
-  implicit def implyReq(builder: RequestBuilder) = Req(_ => builder)
 
   implicit def implyRequestHandlerTuple(builder: Req) =
     new RequestHandlerTupleBuilder(builder)

--- a/core/src/main/scala/requests.scala
+++ b/core/src/main/scala/requests.scala
@@ -1,10 +1,16 @@
 package dispatch
 
-import com.ning.http.client.{FluentStringsMap, BodyGenerator, RequestBuilder}
-import com.ning.http.client.multipart.Part
+import java.nio.charset.Charset
+
+import org.asynchttpclient.Realm.AuthScheme
+import org.asynchttpclient.cookie.Cookie
+import org.asynchttpclient.proxy.ProxyServer
+import org.asynchttpclient.request.body.generator.BodyGenerator
+import org.asynchttpclient.request.body.multipart.Part
+import org.asynchttpclient.{Realm, RequestBuilder}
 
 /** This wrapper provides referential transparency for the
-  underlying RequestBuilder. */
+  * underlying RequestBuilder. */
 case class Req(
   run: RequestBuilder => RequestBuilder,
   props: Req.Properties = Req.Properties()
@@ -19,8 +25,8 @@ with AuthVerbs with HeaderVerbs with RequestBuilderVerbs {
   def toRequestBuilder = {
     val requestBuilder = run(new RequestBuilder)
     //Body set from String and with no Content-Type will get a default of 'text/plain; charset=UTF-8'
-    if(props.bodyType == Req.StringBody && !requestBuilder.build.getHeaders.containsKey("Content-Type")) {
-      setContentType("text/plain", "UTF-8").run(new RequestBuilder)
+    if(props.bodyType == Req.StringBody && !requestBuilder.build.getHeaders.contains("Content-Type")) {
+      setContentType("text/plain", Charset.forName("UTF-8")).run(new RequestBuilder)
     } else {
       requestBuilder
     }
@@ -142,17 +148,11 @@ trait ParamVerbs extends RequestVerbs {
 }
 
 trait AuthVerbs extends RequestVerbs {
-  import com.ning.http.client.Realm, Realm.{RealmBuilder,AuthScheme}
   def as(user: String, password: String): Req =
-    this.as(new RealmBuilder()
-      .setPrincipal(user)
-      .setPassword(password)
-      .build())
+    this.as(new Realm.Builder(user, password).build())
   /** Basic auth, use with care. */
   def as_!(user: String, password: String): Req =
-    this.as(new RealmBuilder()
-      .setPrincipal(user)
-      .setPassword(password)
+    this.as(new Realm.Builder(user, password)
       .setUsePreemptiveAuth(true)
       .setScheme(AuthScheme.BASIC)
       .build())
@@ -162,10 +162,9 @@ trait AuthVerbs extends RequestVerbs {
 }
 
 trait RequestBuilderVerbs extends RequestVerbs {
-  import com.ning.http.client.{ ProxyServer, Realm }
-  import com.ning.http.client.cookie.Cookie
-  import scala.collection.JavaConverters._
   import java.util.Collection
+
+  import scala.collection.JavaConverters._
 
   def addBodyPart(part: Part) =
     subject.underlying { _.addBodyPart(part) }
@@ -178,9 +177,7 @@ trait RequestBuilderVerbs extends RequestVerbs {
   def addQueryParameter(name: String, value: String) =
     subject.underlying { _.addQueryParam(name, value) }
   def setQueryParameters(params: Map[String, Seq[String]]) =
-    subject.underlying { _.setQueryParams(new FluentStringsMap(
-      params.mapValues{ _.asJava: Collection[String] }.asJava
-    )) }
+    subject.underlying { _.setQueryParams(params.mapValues(_.toList.asJava).asJava) }
   def setBody(data: Array[Byte]) =
     subject.underlying(rb => rb.setBody(data), p => p.copy(bodyType = Req.ByteArrayBody))
   def setBody(dataWriter: BodyGenerator, length: Long) =
@@ -191,12 +188,12 @@ trait RequestBuilderVerbs extends RequestVerbs {
     subject.underlying(rb => rb.setBody(data), p => p.copy(bodyType = Req.StringBody))
   def setBody(file: java.io.File) =
     subject.underlying(rb => rb.setBody(file), p => p.copy(bodyType = Req.FileBody))
-  def setBodyEncoding(charset: String) =
-    subject.underlying { _.setBodyEncoding(charset) }
-  def setContentType(mediaType: String, charset: String) =
+  def setBodyEncoding(charset: Charset) =
+    subject.underlying { _.setCharset(charset) }
+  def setContentType(mediaType: String, charset: Charset) =
     subject.underlying {
       _.setHeader("Content-Type", mediaType + "; charset=" + charset).
-      setBodyEncoding(charset)
+      setCharset(charset)
     }
   def setHeader(name: String, value: String) =
     subject.underlying { _.setHeader(name, value) }
@@ -217,7 +214,7 @@ trait RequestBuilderVerbs extends RequestVerbs {
   def setVirtualHost(virtualHost: String) =
     subject.underlying { _.setVirtualHost(virtualHost) }
   def setFollowRedirects(followRedirects: Boolean) =
-    subject.underlying { _.setFollowRedirects(followRedirects) }
+    subject.underlying { _.setFollowRedirect(followRedirects) }
   def addOrReplaceCookie(cookie: Cookie) =
     subject.underlying { _.addOrReplaceCookie(cookie) }
   def setRealm(realm: Realm) =

--- a/core/src/main/scala/retry/retries.scala
+++ b/core/src/main/scala/retry/retries.scala
@@ -3,7 +3,7 @@ package dispatch.retry
 import scala.concurrent.{Future,ExecutionContext}
 import scala.concurrent.duration.Duration
 import java.util.concurrent.TimeUnit
-import org.jboss.netty.util.Timer
+import io.netty.util.Timer
 
 import dispatch._
 

--- a/core/src/main/scala/sleep.scala
+++ b/core/src/main/scala/sleep.scala
@@ -1,9 +1,8 @@
 package dispatch
 
-import org.jboss.netty.util.{TimerTask, Timeout, Timer}
+import io.netty.util.{TimerTask, Timeout, Timer}
 import scala.concurrent.{ExecutionContext}
 import scala.concurrent.duration.Duration
-import java.util.{concurrent => juc}
 
 object SleepFuture {
   def apply[T](d: Duration)(todo: => T)

--- a/core/src/main/scala/stream/strings.scala
+++ b/core/src/main/scala/stream/strings.scala
@@ -1,12 +1,14 @@
 package dispatch.stream
 
-import com.ning.http.client._
-import com.ning.http.util.AsyncHttpProviderUtils.parseCharset
+import java.nio.charset.Charset
+
+import org.asynchttpclient._
+import org.asynchttpclient.util.HttpUtils
 
 trait Strings[T] extends AsyncHandler[T] {
-  import AsyncHandler.STATE._
+  import AsyncHandler.State._
 
-  @volatile private var charset = "iso-8859-1"
+  @volatile private var charset = Charset.forName("iso-8859-1")
   @volatile private var state = CONTINUE
 
   def onThrowable(t: Throwable) { }
@@ -14,8 +16,8 @@ trait Strings[T] extends AsyncHandler[T] {
   def onStatusReceived(status: HttpResponseStatus) = state
   def onHeadersReceived(headers: HttpResponseHeaders) = {
     for {
-      ct <- Option(headers.getHeaders.getFirstValue("content-type"))
-      cs <- Option(parseCharset(ct))
+      ct <- Option(headers.getHeaders.get("content-type"))
+      cs <- Option(HttpUtils.parseCharset(ct))
     } charset = cs
     state
   }

--- a/core/src/test/scala/basic.scala
+++ b/core/src/test/scala/basic.scala
@@ -1,5 +1,7 @@
 package dispatch.spec
 
+import java.nio.charset.Charset
+
 import org.scalacheck._
 
 object BasicSpecification
@@ -128,7 +130,7 @@ with DispatchCleanup {
 
   property("Send a custom content type after <<") = forAll(Gen.oneOf("application/json", "application/foo")) { (sample: String) =>
     val res = Http(
-      (localhost / "contenttype" << "request body").setContentType(sample, "UTF-8") > as.String
+      (localhost / "contenttype" << "request body").setContentType(sample, Charset.forName("UTF-8")) > as.String
     )
     res() ?= (sample + "; charset=UTF-8")
   }

--- a/core/src/test/scala/retry.scala
+++ b/core/src/test/scala/retry.scala
@@ -23,7 +23,7 @@ with DispatchCleanup {
   import scala.concurrent.duration.Duration
   import java.util.concurrent.TimeUnit
 
-  import org.jboss.netty.util.{Timer, HashedWheelTimer}
+  import io.netty.util.{Timer, HashedWheelTimer}
   // We're using a very fine grained timer, and short retry intervals,
   // to keep the tests fast. These are unlikely to be good settings
   // for an application.

--- a/json4sjackson/build.sbt
+++ b/json4sjackson/build.sbt
@@ -6,7 +6,7 @@ description :=
 Seq(lsSettings :_*)
 
 libraryDependencies ++= Seq(
-  "org.json4s" %% "json4s-jackson" % "3.2.11",
+  "org.json4s" %% "json4s-jackson" % "3.3.0",
   "net.databinder" %% "unfiltered-netty" % "0.8.4" % "test"
 )
 

--- a/json4sjackson/src/main/scala/as/json.scala
+++ b/json4sjackson/src/main/scala/as/json.scala
@@ -2,7 +2,7 @@ package dispatch.as.json4s
 
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
-import com.ning.http.client.Response
+import org.asynchttpclient.Response
 
 object Json extends (Response => JValue) {
   def apply(r: Response) =

--- a/json4snative/build.sbt
+++ b/json4snative/build.sbt
@@ -6,8 +6,8 @@ description :=
 Seq(lsSettings :_*)
 
 libraryDependencies ++= Seq(
-  "org.json4s" %% "json4s-core" % "3.2.11",
-  "org.json4s" %% "json4s-native" % "3.2.11",
+  "org.json4s" %% "json4s-core" % "3.3.0",
+  "org.json4s" %% "json4s-native" % "3.3.0",
   "net.databinder" %% "unfiltered-netty" % "0.8.4" % "test"
 )
 

--- a/json4snative/src/main/scala/as/json.scala
+++ b/json4snative/src/main/scala/as/json.scala
@@ -2,7 +2,7 @@ package dispatch.as.json4s
 
 import org.json4s._
 import org.json4s.native.JsonMethods._
-import com.ning.http.client.Response
+import org.asynchttpclient.Response
 
 object Json extends (Response => JValue) {
   def apply(r: Response) =

--- a/jsoup/build.sbt
+++ b/jsoup/build.sbt
@@ -5,4 +5,4 @@ description :=
 
 Seq(lsSettings :_*)
 
-libraryDependencies += "org.jsoup" % "jsoup" % "1.8.3"
+libraryDependencies += "org.jsoup" % "jsoup" % "1.9.1"

--- a/jsoup/build.sbt
+++ b/jsoup/build.sbt
@@ -5,4 +5,4 @@ description :=
 
 Seq(lsSettings :_*)
 
-libraryDependencies += "org.jsoup" % "jsoup" % "1.8.1"
+libraryDependencies += "org.jsoup" % "jsoup" % "1.8.3"

--- a/jsoup/src/main/scala/as/soup.scala
+++ b/jsoup/src/main/scala/as/soup.scala
@@ -2,7 +2,7 @@ package dispatch.as.jsoup
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes
-import com.ning.http.client.Response
+import org.asynchttpclient.Response
 
 object Document extends (Response => nodes.Document) {
   def apply(r: Response) =

--- a/liftjson/build.sbt
+++ b/liftjson/build.sbt
@@ -6,6 +6,6 @@ description :=
 Seq(lsSettings :_*)
 
 libraryDependencies ++= Seq(
-  "net.liftweb" %% "lift-json" % "2.6",
+  "net.liftweb" %% "lift-json" % "2.6.3",
   "org.mockito" % "mockito-core" % "1.10.19" % "test"
 )

--- a/liftjson/src/main/scala/as/json.scala
+++ b/liftjson/src/main/scala/as/json.scala
@@ -1,7 +1,7 @@
 package dispatch.as.lift
 
 import net.liftweb.json.{ JsonParser, JValue }
-import com.ning.http.client.Response
+import org.asynchttpclient.Response
 
 object Json extends (Response => JValue) {
   def apply(r: Response) =

--- a/liftjson/src/test/scala/json.scala
+++ b/liftjson/src/test/scala/json.scala
@@ -4,7 +4,7 @@ import org.scalacheck._
 import net.liftweb.json._
 import JsonDSL._
 import dispatch._
-import com.ning.http.client._
+import org.asynchttpclient._
 import org.mockito.Mockito._
 
 object BasicSpecification extends Properties("Lift Json") {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.11

--- a/project/build.scala
+++ b/project/build.scala
@@ -53,7 +53,7 @@ object Builds extends sbt.Build {
   lazy val xmlDependency = libraryDependencies <<= (libraryDependencies, scalaVersion){
     (dependencies, scalaVersion) =>
       if(scalaVersion.startsWith("2.11"))
-        ("org.scala-lang.modules" %% "scala-xml" % "1.0.1") +: dependencies
+        ("org.scala-lang.modules" %% "scala-xml" % "1.0.5") +: dependencies
       else
         dependencies
     }

--- a/project/common.scala
+++ b/project/common.scala
@@ -13,7 +13,7 @@ object Common {
   )
 
   val settings: Seq[Setting[_]] = ls.Plugin.lsSettings ++ Seq(
-    version := "0.11.3",
+    version := "0.11.4",
 
     crossScalaVersions := Seq("2.10.6", "2.11.8"),
 

--- a/project/common.scala
+++ b/project/common.scala
@@ -3,7 +3,7 @@ import sbt._
 object Common {
   import Keys._
 
-  val defaultScalaVersion = "2.11.5"
+  val defaultScalaVersion = "2.11.8"
 
   val testSettings:Seq[Setting[_]] = Seq(
     testOptions in Test += Tests.Cleanup { loader =>
@@ -15,7 +15,7 @@ object Common {
   val settings: Seq[Setting[_]] = ls.Plugin.lsSettings ++ Seq(
     version := "0.11.3",
 
-    crossScalaVersions := Seq("2.10.4", "2.11.5"),
+    crossScalaVersions := Seq("2.10.6", "2.11.8"),
 
     scalaVersion := defaultScalaVersion,
 

--- a/tagsoup/src/main/scala/as/soup.scala
+++ b/tagsoup/src/main/scala/as/soup.scala
@@ -1,9 +1,8 @@
 package dispatch.as.tagsoup
 
-import com.ning.http.client.Response
+import org.asynchttpclient.Response
 import xml.{NodeSeq => XNodeSeq}
 import xml.parsing.NoBindingFactoryAdapter
-import java.io.StringReader
 import org.xml.sax.InputSource
 import org.ccil.cowan.tagsoup.jaxp.SAXFactoryImpl
 


### PR DESCRIPTION
No hack is necessary to exit cleanly in SBT now.
The client config is not public anymore, so only the default config can be customized.

Note: Play Framework 2.5 already switched to AHC 2.0.
