### PR TITLE
Fix SBT warning about multiple resolvers for sbt-plugin-releases

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,5 +6,3 @@ resolvers ++= Seq(
   "less is" at "http://repo.lessis.me",
   "coda" at "http://repo.codahale.com"
 )
-
-resolvers += Resolver.url("sbt-plugin-releases", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases/"))(Resolver.ivyStylePatterns)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,3 @@
 addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.3")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.3.1")
-
-resolvers ++= Seq(
-  "less is" at "http://repo.lessis.me",
-  "coda" at "http://repo.codahale.com"
-)


### PR DESCRIPTION
Multiple resolvers having different access mechanism configured with
same name 'sbt-plugin-releases'. To avoid conflict, Remove duplicate
project resolvers (`resolvers`) or rename publishing resolver
(`publishTo`).
