### PR TITLE
Fix Travis by upgrading Scala and host addon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,6 @@ scala:
   - 2.11.5
 jdk:
   - openjdk7
+addons:
+  hosts:
+    - dummy

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ before_script:
  - "export JAVA_OPTS='-Xmx512m -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M'"
 language: scala
 scala:
-  - 2.9.3
+  - 2.10.4
+  - 2.11.5
 jdk:
   - openjdk7


### PR DESCRIPTION
Travis builds fail for a couple of reasons:
- It is set to build on Scala 2.9.4 which gives problems with resolving dependencies in SBT.  Dispatch no longer supports 2.9 officially, so the Travis config should have been modified as such.
- There's a nasty bug in openjdk7 with Travis that causes it to dump core.  There is now an addon called hosts https://docs.travis-ci.com/user/hosts
