### PR TITLE
Turn on Scala lint warnings

### DIFF
--- a/core/src/main/scala/as/stream/lines.scala
+++ b/core/src/main/scala/as/stream/lines.scala
@@ -9,6 +9,7 @@ object Lines {
     new stream.StringsByLine[Unit] {
       def onStringBy(string: String) {
         f(string)
+        ()
       }
       def onCompleted = ()
     }

--- a/core/src/main/scala/as/stream/lines.scala
+++ b/core/src/main/scala/as/stream/lines.scala
@@ -7,7 +7,7 @@ import com.ning.http.client._
 object Lines {
   def apply[U](f: String => U) =
     new stream.StringsByLine[Unit] {
-      def onStringBy(string: String) {
+      def onStringBy(string: String) = {
         f(string)
         ()
       }

--- a/core/src/main/scala/defaults.scala
+++ b/core/src/main/scala/defaults.scala
@@ -54,6 +54,7 @@ private [dispatch] object InternalDefaults {
           nioClientSocketChannelFactory.releaseExternalResources()
           timer.stop()
         }
+        ()
       }
       /** daemon threads that also shut down everything when interrupted! */
       lazy val interruptThreadFactory = new juc.ThreadFactory {

--- a/core/src/main/scala/defaults.scala
+++ b/core/src/main/scala/defaults.scala
@@ -49,7 +49,7 @@ private [dispatch] object InternalDefaults {
     def builder = {
       val shuttingDown = new juc.atomic.AtomicBoolean(false)
 
-      def shutdown() {
+      def shutdown() = {
         if (shuttingDown.compareAndSet(false, true)) {
           nioClientSocketChannelFactory.releaseExternalResources()
           timer.stop()
@@ -62,7 +62,7 @@ private [dispatch] object InternalDefaults {
           new Thread(runnable) {
             setDaemon(true)
             /** only reliably called on any thread if all spawned threads are daemon */
-            override def interrupt() {
+            override def interrupt() = {
               shutdown()
               super.interrupt()
             }

--- a/core/src/main/scala/defaults.scala
+++ b/core/src/main/scala/defaults.scala
@@ -49,7 +49,7 @@ private [dispatch] object InternalDefaults {
     def builder = {
       val shuttingDown = new juc.atomic.AtomicBoolean(false)
 
-      def shutdown() = {
+      def shutdown(): Unit = {
         if (shuttingDown.compareAndSet(false, true)) {
           nioClientSocketChannelFactory.releaseExternalResources()
           timer.stop()

--- a/core/src/main/scala/enrich.scala
+++ b/core/src/main/scala/enrich.scala
@@ -68,10 +68,10 @@ class EnrichedFuture[A](underlying: Future[A]) {
 object EnrichedFuture {
   /** Execute on the current thread, for certain cpu-bound operations */
   private val currentThreadContext = new ExecutionContext {
-    def execute(runnable: Runnable) {
+    def execute(runnable: Runnable) = {
       runnable.run()
     }
-    def reportFailure(t: Throwable) {
+    def reportFailure(t: Throwable) = {
       ExecutionContext.defaultReporter(t)
     }
   }

--- a/core/src/main/scala/execution.scala
+++ b/core/src/main/scala/execution.scala
@@ -49,7 +49,7 @@ trait HttpExecutor { self =>
     lfut.addListener(
       () => promise.complete(util.Try(lfut.get())),
       new juc.Executor {
-        def execute(runnable: Runnable) {
+        def execute(runnable: Runnable) = {
           executor.execute(runnable)
         }
       }
@@ -57,7 +57,7 @@ trait HttpExecutor { self =>
     promise.future
   }
 
-  def shutdown() {
+  def shutdown() = {
     client.close()
   }
 }

--- a/core/src/main/scala/package.scala
+++ b/core/src/main/scala/package.scala
@@ -15,7 +15,7 @@ package object dispatch {
 
 
   implicit def implyRunnable[U](f: () => U) = new java.lang.Runnable {
-    def run() { f() }
+    def run() { f(); () }
   }
 
   implicit def enrichFuture[T](future: Future[T]) =

--- a/core/src/main/scala/package.scala
+++ b/core/src/main/scala/package.scala
@@ -15,7 +15,7 @@ package object dispatch {
 
 
   implicit def implyRunnable[U](f: () => U) = new java.lang.Runnable {
-    def run() { f(); () }
+    def run() = { f(); () }
   }
 
   implicit def enrichFuture[T](future: Future[T]) =

--- a/core/src/main/scala/projections.scala
+++ b/core/src/main/scala/projections.scala
@@ -21,7 +21,7 @@ object FutureEither {
         _.left.map(f)
       }
 
-    def foreach[U](f: A => U) {
+    def foreach[U](f: A => U) = {
       underlying.foreach { _.left.foreach(f) }
     }
   }
@@ -39,7 +39,7 @@ object FutureEither {
         _.right.map(f)
       }
 
-    def foreach(f: B => Unit) {
+    def foreach(f: B => Unit) = {
       underlying.foreach { _.right.foreach(f) }
     }
     def values[A1 >: A, C]
@@ -61,7 +61,7 @@ object FutureIterable {
     def map[Iter[B] <: Iterable[B], B](f: A => Iter[B])
     : Future[Iterable[B]] =
       underlying.map { _.map(f) }.map { _.flatten }
-    def foreach(f: A => Unit) {
+    def foreach(f: A => Unit) = {
       underlying.foreach { _.foreach(f) }
     }
     def withFilter(p: A => Boolean) =
@@ -77,7 +77,7 @@ object FutureIterable {
       }
     def map[B](f: A => B): Future[Iterable[B]] =
       underlying.map { _.map(f) }
-    def foreach(f: A => Unit) {
+    def foreach(f: A => Unit) = {
       underlying.foreach { _.foreach(f) }
     }
     def withFilter(p: A => Boolean) =
@@ -114,7 +114,7 @@ object FutureRightIterable {
       underlying.flatMap { iter =>
         Future.successful(Right(iter.map(f).flatten))
       }
-    def foreach(f: A => Unit) {
+    def foreach(f: A => Unit) = {
       underlying.foreach { _.foreach(f) }
     }
     def withFilter(p: A => Boolean) =
@@ -132,7 +132,7 @@ object FutureRightIterable {
       underlying.flatMap { iter =>
         Future.successful(Right(iter.map(f)))
     }
-    def foreach(f: A => Unit) {
+    def foreach(f: A => Unit) = {
       underlying.foreach { _.foreach(f) }
     }
     def flatten = new Flatten(parent, underlying)

--- a/core/src/main/scala/sleep.scala
+++ b/core/src/main/scala/sleep.scala
@@ -12,7 +12,7 @@ object SleepFuture {
     val promise = scala.concurrent.Promise[T]()
 
     val sleepTimeout = timer.newTimeout(new TimerTask {
-      def run(timeout: Timeout) {
+      def run(timeout: Timeout) = {
         promise.complete(util.Try(todo))
         ()
       }

--- a/core/src/main/scala/sleep.scala
+++ b/core/src/main/scala/sleep.scala
@@ -14,6 +14,7 @@ object SleepFuture {
     val sleepTimeout = timer.newTimeout(new TimerTask {
       def run(timeout: Timeout) {
         promise.complete(util.Try(todo))
+        ()
       }
     }, d.length, d.unit)
 

--- a/core/src/main/scala/stream/strings.scala
+++ b/core/src/main/scala/stream/strings.scala
@@ -9,7 +9,7 @@ trait Strings[T] extends AsyncHandler[T] {
   @volatile private var charset = "iso-8859-1"
   @volatile private var state = CONTINUE
 
-  def onThrowable(t: Throwable) { }
+  def onThrowable(t: Throwable) = { }
   def onCompleted(): T
   def onStatusReceived(status: HttpResponseStatus) = state
   def onHeadersReceived(headers: HttpResponseHeaders) = {
@@ -26,7 +26,7 @@ trait Strings[T] extends AsyncHandler[T] {
     }
     state
   }
-  def stop() {
+  def stop() = {
     state = ABORT
   }
 }
@@ -38,7 +38,7 @@ trait StringsBy[T] extends Strings[T] {
 
   def onStringBy(string: String)
 
-  def onString(string: String) {
+  def onString(string: String) = {
     val strings = (buffer + string).split(divider, -1)
     strings.take(strings.length - 1).filter { !_.isEmpty }.foreach(onStringBy)
     buffer = strings.last

--- a/core/src/main/scala/stream/strings.scala
+++ b/core/src/main/scala/stream/strings.scala
@@ -19,7 +19,7 @@ trait Strings[T] extends AsyncHandler[T] {
     } charset = cs
     state
   }
-  def onString(str: String)
+  def onString(str: String): Unit
   def onBodyPartReceived(bodyPart: HttpResponseBodyPart) = {
     if (state == CONTINUE) {
       onString(new String(bodyPart.getBodyPartBytes, charset))
@@ -36,7 +36,7 @@ trait StringsBy[T] extends Strings[T] {
 
   def divider: String
 
-  def onStringBy(string: String)
+  def onStringBy(string: String): Unit
 
   def onString(string: String) = {
     val strings = (buffer + string).split(divider, -1)

--- a/core/src/main/scala/uri.scala
+++ b/core/src/main/scala/uri.scala
@@ -52,7 +52,7 @@ object UriEncode {
   )
   val segmentValid = (';' +: pchar).toSet
 
-  private val validMarkers = (0 to segmentValid.max) map { i => segmentValid(i.toChar) } toArray
+  private val validMarkers = (0 to segmentValid.max).map(i => segmentValid(i.toChar)).toArray
   private def isValidChar(ch: Char) = (ch < validMarkers.length) && validMarkers(ch)
 
   def path(pathSegment: String, encoding: String = "UTF-8") = {

--- a/core/src/main/scala/uri.scala
+++ b/core/src/main/scala/uri.scala
@@ -52,8 +52,8 @@ object UriEncode {
   )
   val segmentValid = (';' +: pchar).toSet
 
-  private val validMarkers = (0 to segmentValid.max).map(i => segmentValid(i.toChar)).toArray
-  private def isValidChar(ch: Char) = (ch < validMarkers.length) && validMarkers(ch)
+  private val validMarkers = (0 to segmentValid.max.toInt).map(i => segmentValid(i.toChar)).toArray
+  private def isValidChar(ch: Char) = (ch < validMarkers.length) && validMarkers(ch.toInt)
 
   def path(pathSegment: String, encoding: String = "UTF-8") = {
     if (pathSegment.forall(isValidChar)) {

--- a/core/src/test/scala/cleanup.scala
+++ b/core/src/test/scala/cleanup.scala
@@ -3,7 +3,7 @@ package dispatch.spec
 trait DispatchCleanup extends unfiltered.spec.ServerCleanup {
   implicit def executor = dispatch.Defaults.executor
 
-  override def cleanup() {
+  override def cleanup() = {
     super.cleanup()
     dispatch.Http.shutdown()
   }

--- a/json4sjackson/src/main/scala/as/stream/json.scala
+++ b/json4sjackson/src/main/scala/as/stream/json.scala
@@ -9,6 +9,7 @@ object Json {
     new StringsByLine[Unit] {
       def onStringBy(string: String) {
         f(parse(string, true))
+        ()
       }
       def onCompleted = ()
     }

--- a/json4sjackson/src/main/scala/as/stream/json.scala
+++ b/json4sjackson/src/main/scala/as/stream/json.scala
@@ -7,7 +7,7 @@ import org.json4s.jackson.JsonMethods._
 object Json {
   def apply[T](f: JValue => T) =
     new StringsByLine[Unit] {
-      def onStringBy(string: String) {
+      def onStringBy(string: String) = {
         f(parse(string, true))
         ()
       }

--- a/json4snative/src/main/scala/as/stream/json.scala
+++ b/json4snative/src/main/scala/as/stream/json.scala
@@ -9,6 +9,7 @@ object Json {
     new StringsByLine[Unit] {
       def onStringBy(string: String) {
         f(parse(string, true))
+        ()
       }
       def onCompleted = ()
     }

--- a/json4snative/src/main/scala/as/stream/json.scala
+++ b/json4snative/src/main/scala/as/stream/json.scala
@@ -7,7 +7,7 @@ import org.json4s.native.JsonMethods._
 object Json {
   def apply[T](f: JValue => T) =
     new StringsByLine[Unit] {
-      def onStringBy(string: String) {
+      def onStringBy(string: String) = {
         f(parse(string, true))
         ()
       }

--- a/liftjson/src/main/scala/as/stream/json.scala
+++ b/liftjson/src/main/scala/as/stream/json.scala
@@ -6,8 +6,9 @@ import net.liftweb.json.{ JsonParser, JValue }
 object Json {
   def apply[T](f: JValue => T) =
     new StringsByLine[Unit] {
-      def onStringBy(string: String) {
+      def onStringBy(string: String) = {
         f(JsonParser.parse(string))
+        ()
       }
       def onCompleted = ()
     }

--- a/project/common.scala
+++ b/project/common.scala
@@ -19,6 +19,19 @@ object Common {
 
     scalaVersion := defaultScalaVersion,
 
+    scalacOptions in (Compile) ++= Seq(
+      "-deprecation",
+      "-feature",
+      "-unchecked",
+      // "-Xfatal-warnings",
+      "-Xlint",
+      "-Yno-adapted-args",
+      "-Ywarn-dead-code",
+      "-Ywarn-numeric-widen",
+      "-Ywarn-value-discard",
+      "-Xfuture"
+    ),
+
     organization := "net.databinder.dispatch",
 
     homepage :=

--- a/project/common.scala
+++ b/project/common.scala
@@ -23,6 +23,7 @@ object Common {
       "-deprecation",
       "-feature",
       "-unchecked",
+      "-language:higherKinds",
       // "-Xfatal-warnings",
       "-Xlint",
       "-Yno-adapted-args",

--- a/project/common.scala
+++ b/project/common.scala
@@ -34,6 +34,14 @@ object Common {
       "-Xfuture"
     ),
 
+    scalacOptions in (Test) ~= { (opts: Seq[String]) =>
+      opts.diff(
+        Seq(
+          "-Xlint"
+        )
+      )
+    },
+
     organization := "net.databinder.dispatch",
 
     homepage :=

--- a/project/common.scala
+++ b/project/common.scala
@@ -24,6 +24,7 @@ object Common {
       "-feature",
       "-unchecked",
       "-language:higherKinds",
+      "-language:implicitConversions",
       // "-Xfatal-warnings",
       "-Xlint",
       "-Yno-adapted-args",

--- a/tagsoup/src/test/scala/soup.scala
+++ b/tagsoup/src/test/scala/soup.scala
@@ -26,7 +26,7 @@ with DispatchCleanup {
     val doc = Http(
       localhost / "echo" <<? Map("echo" -> sample) > as.tagsoup.NodeSeq
     )
-    (doc() \\ "div" find (n => (n \ "@id" text) == "echo") map (_.text) mkString) == (sample)
+    (doc() \\ "div").find (n => (n \ "@id").text == "echo").map (_.text) .mkString == (sample)
   }
 
 }


### PR DESCRIPTION
Add `scalacOptions` to common SBT settings.

Gives 42 warnings in 2.10 and 46 warnings in 2.11.

The warnings could become errors when `-Xfatal-warnings`.

Rob Norris suggested these defaults in a blog post at
https://tpolecat.github.io/2014/04/11/scalac-flags.html
