### PR TITLE
Fix #134 - Scala 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ before_script:
  - "export JAVA_OPTS='-Xmx512m -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M'"
 language: scala
 scala:
-  - 2.9.3
+  - 2.11.8
+  - 2.12.1
 jdk:
-  - openjdk7
+  - oraclejdk8

--- a/json4sjackson/build.sbt
+++ b/json4sjackson/build.sbt
@@ -3,10 +3,10 @@ name := "dispatch-json4s-jackson"
 description :=
   "Dispatch module providing json4s support"
 
-Seq(lsSettings :_*)
+Seq(lsSettings: _*)
 
 libraryDependencies ++= Seq(
-  "org.json4s" %% "json4s-jackson" % "3.2.11",
-  "net.databinder" %% "unfiltered-netty" % "0.8.4" % "test"
+  "org.json4s" %% "json4s-jackson" % "3.4.2",
+  "ws.unfiltered" %% "unfiltered-netty-server" % "0.9.0-beta2" % "test"
 )
 

--- a/json4snative/build.sbt
+++ b/json4snative/build.sbt
@@ -5,9 +5,10 @@ description :=
 
 Seq(lsSettings :_*)
 
-libraryDependencies ++= Seq(
-  "org.json4s" %% "json4s-core" % "3.2.11",
-  "org.json4s" %% "json4s-native" % "3.2.11",
-  "net.databinder" %% "unfiltered-netty" % "0.8.4" % "test"
-)
+val json4sVersion = "3.4.2"
 
+libraryDependencies ++= Seq(
+  "org.json4s" %% "json4s-core" % json4sVersion,
+  "org.json4s" %% "json4s-native" % json4sVersion,
+  "ws.unfiltered" %% "unfiltered-netty-server" % "0.9.0-beta2" % "test"
+)

--- a/liftjson/build.sbt
+++ b/liftjson/build.sbt
@@ -6,6 +6,6 @@ description :=
 Seq(lsSettings :_*)
 
 libraryDependencies ++= Seq(
-  "net.liftweb" %% "lift-json" % "2.6",
+  "net.liftweb" %% "lift-json" % "3.0.1",
   "org.mockito" % "mockito-core" % "1.10.19" % "test"
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=0.13.13

--- a/project/build.scala
+++ b/project/build.scala
@@ -50,17 +50,14 @@ object Builds extends sbt.Build {
     .dependsOn(core)
     .dependsOn(core % "test->test")
     
-  lazy val xmlDependency = libraryDependencies <<= (libraryDependencies, scalaVersion){
-    (dependencies, scalaVersion) =>
-      if(scalaVersion.startsWith("2.11"))
-        ("org.scala-lang.modules" %% "scala-xml" % "1.0.1") +: dependencies
-      else
-        dependencies
-    }
+  lazy val xmlDependency = libraryDependencies ++= Seq("org.scala-lang.modules" %% "scala-xml" % "1.0.6")
 
   /** Util module for using unfiltered with scalacheck */
   lazy val ufcheck = Project(
-    "ufcheck", file("ufcheck"), settings =
-      Defaults.defaultSettings ++ Seq(scalaVersion := Common.defaultScalaVersion)
+    "ufcheck", file("ufcheck")
+  ).settings(
+    scalaVersion := Common.defaultScalaVersion
   )
+
+  scalacOptions ++= Seq( "-unchecked", "-deprecation" )
 }

--- a/project/common.scala
+++ b/project/common.scala
@@ -3,7 +3,7 @@ import sbt._
 object Common {
   import Keys._
 
-  val defaultScalaVersion = "2.11.5"
+  val defaultScalaVersion = "2.12.1"
 
   val testSettings:Seq[Setting[_]] = Seq(
     testOptions in Test += Tests.Cleanup { loader =>
@@ -15,7 +15,7 @@ object Common {
   val settings: Seq[Setting[_]] = ls.Plugin.lsSettings ++ Seq(
     version := "0.11.3",
 
-    crossScalaVersions := Seq("2.10.4", "2.11.5"),
+    crossScalaVersions := Seq("2.11.8", "2.12.1"),
 
     scalaVersion := defaultScalaVersion,
 
@@ -38,7 +38,7 @@ object Common {
 
     licenses := Seq("LGPL v3" -> url("http://www.gnu.org/licenses/lgpl.txt")),
 
-    pomExtra := (
+    pomExtra :=
       <scm>
         <url>git@github.com:dispatch/reboot.git</url>
         <connection>scm:git:git@github.com:dispatch/reboot.git</connection>
@@ -49,6 +49,6 @@ object Common {
           <name>Nathan Hamblen</name>
           <url>http://twitter.com/n8han</url>
         </developer>
-      </developers>)
+      </developers>
   )
 }

--- a/ufcheck/build.sbt
+++ b/ufcheck/build.sbt
@@ -1,5 +1,5 @@
 libraryDependencies ++= Seq(
-  "org.scalacheck" %% "scalacheck" % "1.11.3" % "test",
-  "net.databinder" %% "unfiltered-netty-server" % "0.8.0" % "test",
+  "org.scalacheck" %% "scalacheck" % "1.11.6" % "test",
+  "ws.unfiltered" %% "unfiltered-netty-server" % "0.9.0-beta2" % "test",
   "org.slf4j" % "slf4j-simple" % "1.6.4" % "test"
 )


### PR DESCRIPTION
Fixes #134 . This introduces support for scala 2.12, whilst dropping 2.10. It uses the 0.9.0-beta2 build of unfiltered.