### PR TITLE
URI decode fails on colon

### DIFF
--- a/core/src/test/scala/uri.scala
+++ b/core/src/test/scala/uri.scala
@@ -1,13 +1,16 @@
 package dispatch.spec
 
 import org.scalacheck._
+import org.scalacheck.Prop.BooleanOperators
 
 object UriSpecification extends Properties("Uri") {
   /** java.net.URLDecoder should *NOT* be used for testing URI segment decoding
    *  because it implements completely different functionality: query parameter decoding
    */
   property("encode-decode") = Prop.forAll { (path: String) =>
-    new java.net.URI(dispatch.UriEncode.path(path)).getPath == path
+    !path.contains(":") ==> { 
+      new java.net.URI(dispatch.UriEncode.path(path)).getPath == path
+    } // else Prop.throws(classOf[java.net.URISyntaxException])
   }
 
   /** if there is nothing to escape, encoder must return original reference */


### PR DESCRIPTION
Add a guard clause to `dispatch.spec.UriSpecification.encode-decode`

Travis found an error case with java.net.URI

    [info] ! Uri.encode-decode: Exception raised on property evaluation.
    [info] > ARG_0: ":"

Verified with this case

    property("travis#185885377") = {
      Prop.throws(classOf[java.net.URISyntaxException]) {
        new java.net.URI(dispatch.UriEncode.path(":"))
      }
    }

Throwing

    java.net.URISyntaxException: Expected scheme name at index 0: :
            at java.net.URI$Parser.fail(URI.java:2848)
            at java.net.URI$Parser.failExpecting(URI.java:2854)
            at java.net.URI$Parser.parse(URI.java:3046)
            at java.net.URI.<init>(URI.java:588)
            at dispatch.spec.UriSpecification$.<init>(uri.scala:15)
            at dispatch.spec.UriSpecification$.<clinit>(uri.scala)

I turned up the volumen on the test generators in Scalacheck and
didn't find come across any other cases besides the colon character.

    > testOnly dispatch.spec.UriSpecification -- -w 1000000
    [info] + Uri.encode-decode: OK, passed 1000000 tests.
    [info] + Uri.noop: OK, passed 1000000 tests.
    [info] Passed: Total 2, Failed 0, Errors 0, Passed 2
    [success] Total time: 35 s