### PR TITLE
Query params are duplicated when using setBody(String) and setContentType

### DIFF
--- a/core/src/main/scala/requests.scala
+++ b/core/src/main/scala/requests.scala
@@ -17,7 +17,7 @@ with AuthVerbs with HeaderVerbs with RequestBuilderVerbs {
     Req(run andThen nextReq, nextProps(props))
 
   def toRequestBuilder = {
-    val requestBuilder = run(new RequestBuilder)
+    def requestBuilder = run(new RequestBuilder)
     //Body set from String and with no Content-Type will get a default of 'text/plain; charset=UTF-8'
     if(props.bodyType == Req.StringBody && !requestBuilder.build.getHeaders.containsKey("Content-Type")) {
       setContentType("text/plain", "UTF-8").run(new RequestBuilder)

--- a/core/src/test/scala/basic.scala
+++ b/core/src/test/scala/basic.scala
@@ -139,4 +139,16 @@ with DispatchCleanup {
     )
     res() ?= (sample)
   }
+
+  property("Set query params with <<? after setBody(String) and setContentType") = {
+    forAll(Gen.mapOf(Gen.zip(
+      Gen.alphaStr.suchThat(_.nonEmpty),
+      Gen.alphaStr
+    ))) { (sample : Map[String, String]) =>
+      val expectedParams = sample.map { case (key, value) => "%s=%s".format(key, value) }
+      val expectedStr = if (expectedParams.nonEmpty) "?" + expectedParams.mkString("&") else ""
+      val req = localhost.setBody("").setContentType("text/plain", "UTF-8") <<? sample
+      req.toRequest.getUrl ?= "http://127.0.0.1:%d/%s".format(server.port, expectedStr)
+    }
+  }
 }

--- a/core/src/test/scala/basic.scala
+++ b/core/src/test/scala/basic.scala
@@ -144,11 +144,10 @@ with DispatchCleanup {
     forAll(Gen.mapOf(Gen.zip(
       Gen.alphaStr.suchThat(_.nonEmpty),
       Gen.alphaStr
-    ))) { (sample : Map[String, String]) =>
+    )).suchThat(_.nonEmpty)) { (sample : Map[String, String]) =>
       val expectedParams = sample.map { case (key, value) => "%s=%s".format(key, value) }
-      val expectedStr = if (expectedParams.nonEmpty) "?" + expectedParams.mkString("&") else ""
       val req = localhost.setBody("").setContentType("text/plain", "UTF-8") <<? sample
-      req.toRequest.getUrl ?= "http://127.0.0.1:%d/%s".format(server.port, expectedStr)
+      req.toRequest.getUrl ?= "http://127.0.0.1:%d/?%s".format(server.port, expectedParams.mkString("&"))
     }
   }
 }


### PR DESCRIPTION
If setting the request body with setBody and the content type with setContentType, then RequestBuilder.build() will be called twice by Req.toRequest. This results in query parameters being duplicated in the generated URL.