### PR TITLE
Added a test for oauth exchange

### DIFF
--- a/core/src/test/scala/oauth/ExchangeSpec.scala
+++ b/core/src/test/scala/oauth/ExchangeSpec.scala
@@ -1,0 +1,67 @@
+package oauth
+
+import com.ning.http.client.oauth.{ConsumerKey, RequestToken}
+import org.scalacheck.Prop.forAll
+import org.scalacheck.Properties
+
+/**
+  * Tests for oauth / exchange.
+  *
+  * @author Erik-Berndt Scheper
+  * @since 25-01-2017
+  *
+  */
+object ExchangeSpec extends Properties("String") {
+
+  private val safeChars = "[A-Za-z0-9%._~()'!*:@,;-]*"
+  private val urlPattern = s"(.*)[?]oauth_token=($safeChars)[&]oauth_signature=($safeChars)".r
+
+  property("signedAuthorize") = forAll { (keyValue: String, tokenValue: String) =>
+    import dispatch._
+    import dispatch.oauth._
+
+    trait DropboxHttp extends SomeHttp {
+      def http: HttpExecutor = Http
+    }
+
+    trait DropboxConsumer extends SomeConsumer {
+      def consumer: ConsumerKey = new ConsumerKey(keyValue, tokenValue)
+    }
+
+    trait DropboxCallback extends SomeCallback {
+      def callback: String = "oob"
+    }
+
+    trait DropboxEndpoints extends SomeEndpoints {
+      def requestToken: String = "https://api.dropbox.com/1/oauth/request_token"
+
+      def accessToken: String = "https://www.dropbox.com/1/oauth/authorize"
+
+      def authorize: String = "https://api.dropbox.com/1/oauth/access_token"
+    }
+
+    object DropboxExchange extends Exchange
+      with DropboxHttp with DropboxConsumer with DropboxCallback with DropboxEndpoints
+
+    val token = new RequestToken(keyValue, tokenValue)
+    val url = DropboxExchange.signedAuthorize(token)
+
+    val urlMatcher = url match {
+      case urlPattern(path: String, authToken: String, signature: String) =>
+        (path, authToken, signature)
+      case _ =>
+        ("", "", "") // no match
+    }
+
+    val urlPath = urlMatcher._1
+    val authToken = urlMatcher._2
+    val authSignature = urlMatcher._3
+
+    urlPath.equals(DropboxExchange.authorize) &&
+      authToken.length >= keyValue.length &&
+      authToken.matches(safeChars) &&
+      authSignature.length > 0 &&
+      authSignature.matches(safeChars)
+  }
+
+}

--- a/core/src/test/scala/oauth/exchange.scala
+++ b/core/src/test/scala/oauth/exchange.scala
@@ -1,4 +1,4 @@
-package oauth
+package dispatch.oauth.spec
 
 import com.ning.http.client.oauth.{ConsumerKey, RequestToken}
 import org.scalacheck.Prop.forAll
@@ -11,7 +11,7 @@ import org.scalacheck.Properties
   * @since 25-01-2017
   *
   */
-object ExchangeSpec extends Properties("String") {
+object ExchangeSpecification extends Properties("String") {
 
   private val safeChars = "[A-Za-z0-9%._~()'!*:@,;-]*"
   private val urlPattern = s"(.*)[?]oauth_token=($safeChars)[&]oauth_signature=($safeChars)".r


### PR DESCRIPTION
This PR adds the oauth exchange test for the 0.12 branch, which is also included in PR   https://github.com/dispatch/reboot/pull/139 (upgrade AHC to 2.1)