### PR TITLE
Add Java 8 to Travis build for dispatch 0.11.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ scala:
   - 2.11.5
 jdk:
   - openjdk7
+  - oraclejdk8
 addons:
   hosts:
     - dummy


### PR DESCRIPTION
This branch still fails until #136 is cherry-picked on to the 0.11.3 branch