### PR TITLE
Prevent duplication of query params on string body

### DIFF
--- a/core/src/main/scala/requests.scala
+++ b/core/src/main/scala/requests.scala
@@ -17,7 +17,7 @@ with AuthVerbs with HeaderVerbs with RequestBuilderVerbs {
     Req(run andThen nextReq, nextProps(props))
 
   def toRequestBuilder = {
-    val requestBuilder = run(new RequestBuilder)
+    def requestBuilder = run(new RequestBuilder)
     //Body set from String and with no Content-Type will get a default of 'text/plain; charset=UTF-8'
     if(props.bodyType == Req.StringBody && !requestBuilder.build.getHeaders.containsKey("Content-Type")) {
       setContentType("text/plain", "UTF-8").run(new RequestBuilder)

--- a/core/src/test/scala/basic.scala
+++ b/core/src/test/scala/basic.scala
@@ -139,4 +139,15 @@ with DispatchCleanup {
     )
     res() ?= (sample)
   }
+
+  property("Set query params with <<? after setBody(String) and setContentType") = {
+    forAll(Gen.mapOf(Gen.zip(
+      Gen.alphaStr.suchThat(_.nonEmpty),
+      Gen.alphaStr
+    )).suchThat(_.nonEmpty)) { (sample : Map[String, String]) =>
+      val expectedParams = sample.map { case (key, value) => "%s=%s".format(key, value) }
+      val req = localhost.setBody("").setContentType("text/plain", "UTF-8") <<? sample
+      req.toRequest.getUrl ?= "http://127.0.0.1:%d/?%s".format(server.port, expectedParams.mkString("&"))
+    }
+  }
 }


### PR DESCRIPTION
This is the same as [my previous PR](https://github.com/dispatch/reboot/pull/138), but into the 0.12.0 branch.

Is this the correct branch to merge into so the code is included in future releases?