### PR TITLE
Upgrade to AsyncHttpClient 2.0.32

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,6 +11,10 @@ as its underlying transport. For more info, see the
 [docs]: http://dispatch.databinder.net/Dispatch.html
 [async]: https://github.com/AsyncHttpClient/async-http-client
 
+### Dependencies
+* [Async HTTP client](https://github.com/AsyncHttpClient/async-http-client)
+* JDK 8, as required by the Async HTTP client library
+
 ### Mailing List
 
 There's a [mailing list for Dispatch][mail]. Please mail the list **before opening

--- a/build.sbt
+++ b/build.sbt
@@ -48,9 +48,7 @@ lazy val tagsoup = module("tagsoup")
 lazy val xmlDependency = libraryDependencies ++= Seq("org.scala-lang.modules" %% "scala-xml" % "1.0.6")
 
 /** Util module for using unfiltered with scalacheck */
-lazy val ufcheck = Project(
-  "ufcheck", file("ufcheck")
-).settings(
+lazy val ufcheck = project.in(file("ufcheck")).settings(
   scalaVersion := Common.defaultScalaVersion
 )
 

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,10 +1,10 @@
 name := "dispatch-core"
 
 description :=
-  "Core Dispatch module wrapping sonatype/async-http-client"
+  "Core Dispatch module wrapping async-http-client"
 
 libraryDependencies +=
-  "com.ning" % "async-http-client" % "1.9.11"
+  "org.asynchttpclient" % "async-http-client" % "2.0.32"
 
 Seq(lsSettings :_*)
 

--- a/core/src/main/scala/as/core.scala
+++ b/core/src/main/scala/as/core.scala
@@ -2,36 +2,36 @@ package dispatch.as
 
 import dispatch._
 
-import com.ning.http.client
 import java.nio.charset.Charset
+import org.asynchttpclient
 
 object Response {
-  def apply[T](f: client.Response => T) = f
+  def apply[T](f: asynchttpclient.Response => T) = f
 }
 
-object String extends (client.Response => String) {
+object String extends (asynchttpclient.Response => String) {
   /** @return response body as a string decoded as either the charset provided by
    *  Content-Type header of the response or ISO-8859-1 */
-  def apply(r: client.Response) = r.getResponseBody
+  def apply(r: asynchttpclient.Response) = r.getResponseBody
 
   /** @return a function that will return response body decoded in the provided charset */
-  case class charset(set: Charset) extends (client.Response => String) {
-    def apply(r: client.Response) = r.getResponseBody(set.name)
+  case class charset(set: Charset) extends (asynchttpclient.Response => String) {
+    def apply(r: asynchttpclient.Response) = r.getResponseBody(set)
   }
 
   /** @return a function that will return response body as a utf8 decoded string */
   object utf8 extends charset(Charset.forName("utf8"))
 }
 
-object Bytes extends (client.Response => Array[Byte]) {
-  def apply(r: client.Response) = r.getResponseBodyAsBytes
+object Bytes extends (asynchttpclient.Response => Array[Byte]) {
+  def apply(r: asynchttpclient.Response) = r.getResponseBodyAsBytes
 }
 
 object File extends {
   def apply(file: java.io.File) =
-    (new client.resumable.ResumableAsyncHandler with OkHandler[Nothing])
+    (new asynchttpclient.handler.resumable.ResumableAsyncHandler with OkHandler[asynchttpclient.Response])
       .setResumableListener(
-        new client.extra.ResumableRandomAccessFileListener(
+        new asynchttpclient.handler.resumable.ResumableRandomAccessFileListener(
           new java.io.RandomAccessFile(file, "rw")
         )
       )

--- a/core/src/main/scala/as/oauth/token.scala
+++ b/core/src/main/scala/as/oauth/token.scala
@@ -1,8 +1,7 @@
 package dispatch.as.oauth
 
-import dispatch.oauth._
-import com.ning.http.client.Response
-import com.ning.http.client.oauth._
+import org.asynchttpclient.Response
+import org.asynchttpclient.oauth.RequestToken
 
 object Token extends (Response => Either[String, RequestToken]) {
   def apply(res: Response) = tokenDecode(dispatch.as.String(res))

--- a/core/src/main/scala/as/stream/lines.scala
+++ b/core/src/main/scala/as/stream/lines.scala
@@ -2,8 +2,6 @@ package dispatch.as.stream
 
 import dispatch._
 
-import com.ning.http.client._
-
 object Lines {
   def apply[U](f: String => U) =
     new stream.StringsByLine[Unit] {

--- a/core/src/main/scala/defaults.scala
+++ b/core/src/main/scala/defaults.scala
@@ -1,108 +1,35 @@
 package dispatch
 
-import org.jboss.netty.util.{Timer, HashedWheelTimer}
-import org.jboss.netty.channel.socket.nio.{
-  NioClientSocketChannelFactory, NioWorkerPool}
-import java.util.{concurrent => juc}
-import com.ning.http.client.{
-  AsyncHttpClient, AsyncHttpClientConfig
-}
-import com.ning.http.client.providers.netty.NettyAsyncHttpProviderConfig
+import io.netty.util.{HashedWheelTimer, Timer}
+import org.asynchttpclient.DefaultAsyncHttpClientConfig.Builder
+import org.asynchttpclient._
 
 object Defaults {
   implicit def executor = scala.concurrent.ExecutionContext.Implicits.global
+
   implicit lazy val timer: Timer = InternalDefaults.timer
 }
 
-private [dispatch] object InternalDefaults {
-  /** true if we think we're runing un-forked in an sbt-interactive session */
-  val inSbt = (
-    for (group <- Option(Thread.currentThread.getThreadGroup))
-    yield (
-      group.getName == "trap.exit" // sbt version <= 0.13.0
-      || group.getName.startsWith("run-main-group") // sbt 0.13.1+
-    )
-  ).getOrElse(false)
+private[dispatch] object InternalDefaults {
+  private lazy val underlying = BasicDefaults
 
-  private lazy val underlying = 
-    if (inSbt) SbtProcessDefaults
-    else BasicDefaults
-
-  def client = new AsyncHttpClient(underlying.builder.build())
-  lazy val timer = underlying.timer
+  lazy val clientBuilder: Builder = underlying.builder
+  lazy val timer: Timer = underlying.timer
 
   private trait Defaults {
-    def builder: AsyncHttpClientConfig.Builder
+    def builder: DefaultAsyncHttpClientConfig.Builder
+
     def timer: Timer
   }
 
   /** Sets a user agent, no timeout for requests  */
   private object BasicDefaults extends Defaults {
     lazy val timer = new HashedWheelTimer()
-    def builder = new AsyncHttpClientConfig.Builder()
+
+    def builder: Builder = new DefaultAsyncHttpClientConfig.Builder()
       .setUserAgent("Dispatch/%s" format BuildInfo.version)
       .setRequestTimeout(-1) // don't timeout streaming connections
       .setUseProxyProperties(true)
   }
 
-  /** Uses daemon threads and tries to exit cleanly when running in sbt  */
-  private object SbtProcessDefaults extends Defaults {
-    def builder = {
-      val shuttingDown = new juc.atomic.AtomicBoolean(false)
-
-      def shutdown(): Unit = {
-        if (shuttingDown.compareAndSet(false, true)) {
-          nioClientSocketChannelFactory.releaseExternalResources()
-          timer.stop()
-        }
-        ()
-      }
-      /** daemon threads that also shut down everything when interrupted! */
-      lazy val interruptThreadFactory = new juc.ThreadFactory {
-        def newThread(runnable: Runnable) = {
-          new Thread(runnable) {
-            setDaemon(true)
-            /** only reliably called on any thread if all spawned threads are daemon */
-            override def interrupt() = {
-              shutdown()
-              super.interrupt()
-            }
-          }
-        }
-      }
-      lazy val nioClientSocketChannelFactory = {
-        val workerCount = 2 * Runtime.getRuntime().availableProcessors()
-        new NioClientSocketChannelFactory(
-          juc.Executors.newCachedThreadPool(interruptThreadFactory),
-          1,
-          new NioWorkerPool(
-            juc.Executors.newCachedThreadPool(interruptThreadFactory),
-            workerCount
-          ),
-          timer
-        )
-      }
-
-      val config = new NettyAsyncHttpProviderConfig().addProperty(
-        "socketChannelFactory",
-        nioClientSocketChannelFactory
-      )
-      config.setNettyTimer(timer)
-      BasicDefaults.builder.setAsyncHttpClientProviderConfig(config)
-    }
-    lazy val timer = new HashedWheelTimer(DaemonThreads.factory)
-  }
-}
-
-object DaemonThreads {
-  /** produces daemon threads that won't block JVM shutdown */
-  val factory = new juc.ThreadFactory {
-    def newThread(runnable: Runnable): Thread ={
-      val thread = new Thread(runnable)
-      thread.setDaemon(true)
-      thread
-    }
-  }
-  def apply(threadPoolSize: Int) =
-    juc.Executors.newFixedThreadPool(threadPoolSize, factory)
 }

--- a/core/src/main/scala/enrich.scala
+++ b/core/src/main/scala/enrich.scala
@@ -1,11 +1,7 @@
 package dispatch
 
-import com.ning.http.client.ListenableFuture
-import java.util.{concurrent => juc}
-import juc.TimeUnit
 import scala.concurrent.{ExecutionContext,Await,ExecutionException}
 import scala.concurrent.duration.Duration
-import scala.util.control.Exception.{allCatch,catching}
 
 class EnrichedFuture[A](underlying: Future[A]) {
 

--- a/core/src/main/scala/execution.scala
+++ b/core/src/main/scala/execution.scala
@@ -1,36 +1,39 @@
 package dispatch
 
-import com.ning.http.client.{
-  AsyncHttpClient, Request, Response, AsyncHandler,
-  AsyncHttpClientConfig
-}
-
 import java.util.{concurrent => juc}
-import scala.concurrent.{ExecutionContext}
+
+import org.asynchttpclient._
+
+import scala.concurrent.ExecutionContext
+import scala.util.Try
 
 /** Http executor with defaults */
 case class Http(
-  client: AsyncHttpClient = InternalDefaults.client
-) extends HttpExecutor {
-  import AsyncHttpClientConfig.Builder
+                 clientBuilder: DefaultAsyncHttpClientConfig.Builder = InternalDefaults.clientBuilder
+               ) extends HttpExecutor {
 
-  /** Replaces `client` with a new instance configured using the withBuilder
-      function. The current client config is the builder's prototype.  */
-  def configure(withBuilder: Builder => Builder) =
-    copy(client =
-      new AsyncHttpClient(withBuilder(
-        new AsyncHttpClientConfig.Builder(client.getConfig)
-      ).build)
-    )
+  import DefaultAsyncHttpClientConfig.Builder
+
+  lazy val client = new DefaultAsyncHttpClient(clientBuilder.build)
+
+  /*§*
+    * Replaces `clientBuilder` with a new config built using the withBuilder function.
+    * The current client config is the builder's prototype.
+    */
+  def configure(withBuilder: Builder => Builder): Http = {
+    val newBuilder = new Builder(this.clientBuilder.build)
+    copy(clientBuilder = withBuilder(newBuilder))
+  }
 }
 
 /** Singleton default Http executor, can be used directly or altered
- *  with its case-class `copy` */
+  * with its case-class `copy` */
 object Http extends Http(
-  InternalDefaults.client
+  InternalDefaults.clientBuilder
 )
 
-trait HttpExecutor { self =>
+trait HttpExecutor {
+  self =>
   def client: AsyncHttpClient
 
   def apply(req: Req)
@@ -42,12 +45,12 @@ trait HttpExecutor { self =>
     apply(pair._1, pair._2)
 
   def apply[T]
-    (request: Request, handler: AsyncHandler[T])
-    (implicit executor: ExecutionContext): Future[T] = {
+  (request: Request, handler: AsyncHandler[T])
+  (implicit executor: ExecutionContext): Future[T] = {
     val lfut = client.executeRequest(request, handler)
     val promise = scala.concurrent.Promise[T]()
     lfut.addListener(
-      () => promise.complete(util.Try(lfut.get())),
+      () => promise.complete(Try(lfut.get())),
       new juc.Executor {
         def execute(runnable: Runnable) = {
           executor.execute(runnable)

--- a/core/src/main/scala/handlers.scala
+++ b/core/src/main/scala/handlers.scala
@@ -1,7 +1,6 @@
 package dispatch
 
-import com.ning.http.client
-import client.{
+import org.asynchttpclient.{
   Response, AsyncCompletionHandler, AsyncHandler,
   HttpResponseStatus
 }

--- a/core/src/main/scala/oauth/requests.scala
+++ b/core/src/main/scala/oauth/requests.scala
@@ -1,8 +1,7 @@
 package dispatch.oauth
 
-import com.ning.http.client.oauth._
-
 import dispatch._
+import org.asynchttpclient.oauth._
 
 class SigningVerbs(val subject: Req) extends RequestVerbs {
   val emptyToken = new RequestToken(null, "")

--- a/core/src/main/scala/package.scala
+++ b/core/src/main/scala/package.scala
@@ -1,14 +1,8 @@
-import com.ning.http.client.RequestBuilder
-
 package object dispatch {
   /** Type alias for Response, avoid need to import */
-  type Res = com.ning.http.client.Response
+  type Res = org.asynchttpclient.Response
   /** Type alias for URI, avoid need to import */
   type Uri = java.net.URI
-
-  @deprecated("Use `RequestBuilder.underlying` to preserve referential transparency",
-    since="0.11.0")
-  implicit def implyReq(builder: RequestBuilder) = Req(_ => builder)
 
   implicit def implyRequestHandlerTuple(builder: Req) =
     new RequestHandlerTupleBuilder(builder)

--- a/core/src/main/scala/retry/retries.scala
+++ b/core/src/main/scala/retry/retries.scala
@@ -3,7 +3,7 @@ package dispatch.retry
 import scala.concurrent.{Future,ExecutionContext}
 import scala.concurrent.duration.Duration
 import java.util.concurrent.TimeUnit
-import org.jboss.netty.util.Timer
+import io.netty.util.Timer
 
 import dispatch._
 

--- a/core/src/main/scala/sleep.scala
+++ b/core/src/main/scala/sleep.scala
@@ -1,9 +1,8 @@
 package dispatch
 
-import org.jboss.netty.util.{TimerTask, Timeout, Timer}
+import io.netty.util.{TimerTask, Timeout, Timer}
 import scala.concurrent.{ExecutionContext}
 import scala.concurrent.duration.Duration
-import java.util.{concurrent => juc}
 
 object SleepFuture {
   def apply[T](d: Duration)(todo: => T)

--- a/core/src/main/scala/stream/strings.scala
+++ b/core/src/main/scala/stream/strings.scala
@@ -1,12 +1,14 @@
 package dispatch.stream
 
-import com.ning.http.client._
-import com.ning.http.util.AsyncHttpProviderUtils.parseCharset
+import java.nio.charset.Charset
+
+import org.asynchttpclient._
+import org.asynchttpclient.util.HttpUtils
 
 trait Strings[T] extends AsyncHandler[T] {
-  import AsyncHandler.STATE._
+  import AsyncHandler.State._
 
-  @volatile private var charset = "iso-8859-1"
+  @volatile private var charset = Charset.forName("iso-8859-1")
   @volatile private var state = CONTINUE
 
   def onThrowable(t: Throwable) = { }
@@ -14,8 +16,8 @@ trait Strings[T] extends AsyncHandler[T] {
   def onStatusReceived(status: HttpResponseStatus) = state
   def onHeadersReceived(headers: HttpResponseHeaders) = {
     for {
-      ct <- Option(headers.getHeaders.getFirstValue("content-type"))
-      cs <- Option(parseCharset(ct))
+      ct <- Option(headers.getHeaders.get("content-type"))
+      cs <- Option(HttpUtils.parseCharset(ct))
     } charset = cs
     state
   }

--- a/core/src/test/scala/oauth/exchange.scala
+++ b/core/src/test/scala/oauth/exchange.scala
@@ -1,6 +1,6 @@
 package dispatch.oauth.spec
 
-import com.ning.http.client.oauth.{ConsumerKey, RequestToken}
+import org.asynchttpclient.oauth.{ConsumerKey, RequestToken}
 import org.scalacheck.Prop.forAll
 import org.scalacheck.Properties
 

--- a/core/src/test/scala/oauth/exchange.scala
+++ b/core/src/test/scala/oauth/exchange.scala
@@ -1,8 +1,9 @@
 package dispatch.oauth.spec
 
 import org.asynchttpclient.oauth.{ConsumerKey, RequestToken}
+import org.scalacheck.Gen.listOf
 import org.scalacheck.Prop.forAll
-import org.scalacheck.Properties
+import org.scalacheck.{Gen, Properties}
 
 /**
   * Tests for oauth / exchange.
@@ -16,7 +17,9 @@ object ExchangeSpecification extends Properties("String") {
   private val safeChars = "[A-Za-z0-9%._~()'!*:@,;-]*"
   private val urlPattern = s"(.*)[?]oauth_token=($safeChars)[&]oauth_signature=($safeChars)".r
 
-  property("signedAuthorize") = forAll { (keyValue: String, tokenValue: String) =>
+  private val validKeyString: Gen[String] = listOf(Gen.alphaNumChar).map(_.mkString)
+
+  property("signedAuthorize") = forAll(validKeyString, validKeyString) { (keyValue: String, tokenValue: String) =>
     import dispatch._
     import dispatch.oauth._
 

--- a/core/src/test/scala/retry.scala
+++ b/core/src/test/scala/retry.scala
@@ -23,7 +23,7 @@ with DispatchCleanup {
   import scala.concurrent.duration.Duration
   import java.util.concurrent.TimeUnit
 
-  import org.jboss.netty.util.{Timer, HashedWheelTimer}
+  import io.netty.util.{Timer, HashedWheelTimer}
   // We're using a very fine grained timer, and short retry intervals,
   // to keep the tests fast. These are unlikely to be good settings
   // for an application.

--- a/json4sjackson/build.sbt
+++ b/json4sjackson/build.sbt
@@ -7,6 +7,6 @@ Seq(lsSettings: _*)
 
 libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-jackson" % "3.5.1",
-  "ws.unfiltered" %% "unfiltered-netty-server" % "0.9.0-beta2" % "test"
+  "ws.unfiltered" %% "unfiltered-netty-server" % "0.9.0" % "test" excludeAll ExclusionRule(organization = "io.netty")
 )
 

--- a/json4sjackson/build.sbt
+++ b/json4sjackson/build.sbt
@@ -7,6 +7,7 @@ Seq(lsSettings: _*)
 
 libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-jackson" % "3.5.1",
-  "ws.unfiltered" %% "unfiltered-netty-server" % "0.9.0" % "test" excludeAll ExclusionRule(organization = "io.netty")
+  "net.databinder" %% "unfiltered-netty-server" % "0.8.4" % "test" excludeAll ExclusionRule(organization = "io.netty")
 )
 
+resolvers += "Farmdawg's Temp Forks" at "https://dl.bintray.com/farmdawgnation/temp-forks"

--- a/json4sjackson/src/main/scala/as/json.scala
+++ b/json4sjackson/src/main/scala/as/json.scala
@@ -2,7 +2,7 @@ package dispatch.as.json4s
 
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
-import com.ning.http.client.Response
+import org.asynchttpclient.Response
 
 object Json extends (Response => JValue) {
   def apply(r: Response) =

--- a/json4snative/build.sbt
+++ b/json4snative/build.sbt
@@ -10,5 +10,5 @@ val json4sVersion = "3.5.1"
 libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-core" % json4sVersion,
   "org.json4s" %% "json4s-native" % json4sVersion,
-  "ws.unfiltered" %% "unfiltered-netty-server" % "0.9.0-beta2" % "test"
+  "ws.unfiltered" %% "unfiltered-netty-server" % "0.9.0" % "test" excludeAll ExclusionRule(organization = "io.netty")
 )

--- a/json4snative/build.sbt
+++ b/json4snative/build.sbt
@@ -10,5 +10,7 @@ val json4sVersion = "3.5.1"
 libraryDependencies ++= Seq(
   "org.json4s" %% "json4s-core" % json4sVersion,
   "org.json4s" %% "json4s-native" % json4sVersion,
-  "ws.unfiltered" %% "unfiltered-netty-server" % "0.9.0" % "test" excludeAll ExclusionRule(organization = "io.netty")
+  "net.databinder" %% "unfiltered-netty-server" % "0.8.4" % "test" excludeAll ExclusionRule(organization = "io.netty")
 )
+
+resolvers += "Farmdawg's Temp Forks" at "https://dl.bintray.com/farmdawgnation/temp-forks"

--- a/json4snative/src/main/scala/as/json.scala
+++ b/json4snative/src/main/scala/as/json.scala
@@ -2,7 +2,7 @@ package dispatch.as.json4s
 
 import org.json4s._
 import org.json4s.native.JsonMethods._
-import com.ning.http.client.Response
+import org.asynchttpclient.Response
 
 object Json extends (Response => JValue) {
   def apply(r: Response) =

--- a/jsoup/build.sbt
+++ b/jsoup/build.sbt
@@ -5,4 +5,4 @@ description :=
 
 Seq(lsSettings :_*)
 
-libraryDependencies += "org.jsoup" % "jsoup" % "1.8.1"
+libraryDependencies += "org.jsoup" % "jsoup" % "1.9.1"

--- a/jsoup/src/main/scala/as/soup.scala
+++ b/jsoup/src/main/scala/as/soup.scala
@@ -2,7 +2,7 @@ package dispatch.as.jsoup
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes
-import com.ning.http.client.Response
+import org.asynchttpclient.Response
 
 object Document extends (Response => nodes.Document) {
   def apply(r: Response) =

--- a/liftjson/src/main/scala/as/json.scala
+++ b/liftjson/src/main/scala/as/json.scala
@@ -1,7 +1,7 @@
 package dispatch.as.lift
 
 import net.liftweb.json.{ JsonParser, JValue }
-import com.ning.http.client.Response
+import org.asynchttpclient.Response
 
 object Json extends (Response => JValue) {
   def apply(r: Response) =

--- a/liftjson/src/test/scala/json.scala
+++ b/liftjson/src/test/scala/json.scala
@@ -4,7 +4,7 @@ import org.scalacheck._
 import net.liftweb.json._
 import JsonDSL._
 import dispatch._
-import com.ning.http.client._
+import org.asynchttpclient._
 import org.mockito.Mockito._
 
 object BasicSpecification extends Properties("Lift Json") {

--- a/tagsoup/src/main/scala/as/soup.scala
+++ b/tagsoup/src/main/scala/as/soup.scala
@@ -1,9 +1,8 @@
 package dispatch.as.tagsoup
 
-import com.ning.http.client.Response
+import org.asynchttpclient.Response
 import xml.{NodeSeq => XNodeSeq}
 import xml.parsing.NoBindingFactoryAdapter
-import java.io.StringReader
 import org.xml.sax.InputSource
 import org.ccil.cowan.tagsoup.jaxp.SAXFactoryImpl
 

--- a/ufcheck/build.sbt
+++ b/ufcheck/build.sbt
@@ -1,5 +1,7 @@
 libraryDependencies ++= Seq(
   "org.scalacheck" %% "scalacheck" % "1.11.6" % "test",
-  "ws.unfiltered" %% "unfiltered-netty-server" % "0.9.0" % "test" excludeAll ExclusionRule(organization = "io.netty"),
+  "net.databinder" %% "unfiltered-netty-server" % "0.8.4" % "test" excludeAll ExclusionRule(organization = "io.netty"),
   "org.slf4j" % "slf4j-simple" % "1.7.22" % "test"
 )
+
+resolvers += "Farmdawg's Temp Forks" at "https://dl.bintray.com/farmdawgnation/temp-forks"

--- a/ufcheck/build.sbt
+++ b/ufcheck/build.sbt
@@ -1,5 +1,5 @@
 libraryDependencies ++= Seq(
   "org.scalacheck" %% "scalacheck" % "1.11.6" % "test",
-  "ws.unfiltered" %% "unfiltered-netty-server" % "0.9.0-beta2" % "test",
-  "org.slf4j" % "slf4j-simple" % "1.6.4" % "test"
+  "ws.unfiltered" %% "unfiltered-netty-server" % "0.9.0" % "test" excludeAll ExclusionRule(organization = "io.netty"),
+  "org.slf4j" % "slf4j-simple" % "1.7.22" % "test"
 )


### PR DESCRIPTION
First attempt to upgrade to AHC 2.0.32. 
Tests don't work right now, as stated in [PR#139](https://github.com/dispatch/reboot/pull/139).

Edits from maintainers are enabled, so you can update the PR to your unfiltered 0.8.4 cross built against scala 2.12.2. 

After that I'll try to fix up the tests again (if necessary).