### PR TITLE
Implement Http.closeAndConfigure, start migration path for 0.13.x

### DIFF
--- a/core/src/main/scala/execution.scala
+++ b/core/src/main/scala/execution.scala
@@ -23,9 +23,11 @@ case class Http(
    * able to ''continue'' using this Http instance after
    *
    * In Dispatch 0.13.x, this will be changed such that it only causes a resource link if you've
-   * actually used the Http client.
+   * actually used the Http client, but the method is still deprecated and is one that we're
+   * planning to remove. If you need this functionality in the long term, it is recommended that you
+   * change your code to invoke the `.copy` method on the `Http` case class directly.
    */
-  @deprecated("This method is known to cause a resource leak in Dispatch 0.12.x. If you don't need to continue using the original Http instance after invoking this, you should switch to using closeAndConfigure.", "0.12.2")
+  @deprecated("This method is deprecated and will be removed in a future version of dispatch. This method is known to cause a resource leak in Dispatch 0.12.x. If you don't need to continue using the original Http instance after invoking this, you should switch to using closeAndConfigure.", "0.12.2")
   def configure(withBuilder: Builder => Builder): Http = {
     unsafeConfigure(withBuilder)
   }

--- a/core/src/main/scala/execution.scala
+++ b/core/src/main/scala/execution.scala
@@ -48,7 +48,7 @@ case class Http(
    * underlying client for this instance is closed before the new instance is created.
    */
   def closeAndConfigure(withBuilder: Builder => Builder): Http = {
-    client.close()
+    this.shutdown()
     unsafeConfigure(withBuilder)
   }
 }

--- a/core/src/main/scala/execution.scala
+++ b/core/src/main/scala/execution.scala
@@ -57,7 +57,27 @@ case class Http(
  *  with its case-class `copy` */
 object Http extends Http(
   InternalDefaults.client
-)
+) {
+  /**
+   * The default executor. Invoking this val will shutdown the client created by the Http singleton.
+   */
+  lazy val default = {
+    this.closeAndConfigure(builder => builder)
+  }
+
+  @deprecated("Using the Http singleton directly will not be allowed in Dispatch 0.13.x. Please switch to invoking Http.default for using a globally accessible default Http client.", "0.12.2")
+  override def apply(req: Req)
+           (implicit executor: ExecutionContext): Future[Response] = super.apply(req)
+
+  @deprecated("Using the Http singleton directly will not be allowed in Dispatch 0.13.x. Please switch to invoking Http.default for using a globally accessible default Http client.", "0.12.2")
+  override def apply[T](pair: (Request, AsyncHandler[T]))
+              (implicit executor: ExecutionContext): Future[T] = super.apply(pair)
+
+  @deprecated("Using the Http singleton directly will not be allowed in Dispatch 0.13.x. Please switch to invoking Http.default for using a globally accessible default Http client.", "0.12.2")
+  override def apply[T]
+    (request: Request, handler: AsyncHandler[T])
+    (implicit executor: ExecutionContext): Future[T] = super.apply(request, handler)
+}
 
 trait HttpExecutor { self =>
   def client: AsyncHttpClient

--- a/core/src/main/scala/execution.scala
+++ b/core/src/main/scala/execution.scala
@@ -65,15 +65,15 @@ object Http extends Http(
     this.closeAndConfigure(builder => builder)
   }
 
-  @deprecated("Using the Http singleton directly will not be allowed in Dispatch 0.13.x. Please switch to invoking Http.default for using a globally accessible default Http client.", "0.12.2")
+  @deprecated("Using the Http singleton directly is deprecated and will be removed in a future version of dispatch. Please switch to invoking Http.default for using a globally accessible default Http client.", "0.12.2")
   override def apply(req: Req)
            (implicit executor: ExecutionContext): Future[Response] = super.apply(req)
 
-  @deprecated("Using the Http singleton directly will not be allowed in Dispatch 0.13.x. Please switch to invoking Http.default for using a globally accessible default Http client.", "0.12.2")
+  @deprecated("Using the Http singleton directly is deprecated and will be removed in a future version of dispatch. Please switch to invoking Http.default for using a globally accessible default Http client.", "0.12.2")
   override def apply[T](pair: (Request, AsyncHandler[T]))
               (implicit executor: ExecutionContext): Future[T] = super.apply(pair)
 
-  @deprecated("Using the Http singleton directly will not be allowed in Dispatch 0.13.x. Please switch to invoking Http.default for using a globally accessible default Http client.", "0.12.2")
+  @deprecated("Using the Http singleton directly is deprecated and will be removed in a future version of dispatch. Please switch to invoking Http.default for using a globally accessible default Http client.", "0.12.2")
   override def apply[T]
     (request: Request, handler: AsyncHandler[T])
     (implicit executor: ExecutionContext): Future[T] = super.apply(request, handler)


### PR DESCRIPTION
This addresses #53 and other issues in such a way that does not change
underlying behavior in the 0.12.x series. Now, people using Dispatch
0.12.x will get a warning if they attempt to use the configure method
directly.

This has the benefit of not changing the underlying behavior in a minor
release. We will warn using a deprecation warning that this method might
be unsafe, but will permit callers to continue using the Http instance
after invoking it if their application depends on that behavior.

We add a closeAndConfigure method that's the intended "safe" method to
invoke in most cases.

Closes #53 
Closes #59 
Closes #114 

This also makes some changes to help folks start migrating to Dispatch 0.13.x, where we'll start disallowing the use of the `Http` singleton directly to avoid situations where two characters can accidentally cause additional resource allocation. For more information, see #157.