### PR TITLE
Implement more explicit configuration semantics for Http

### DIFF
--- a/core/src/main/scala/execution.scala
+++ b/core/src/main/scala/execution.scala
@@ -87,6 +87,19 @@ object Http {
     val newBuilder = new Builder(defaultClientBuilder.build)
     Http(withBuilder(newBuilder))
   }
+
+  @deprecated("Using the Http singleton directly is deprecated and will be removed in a future version of dispatch. Please switch to invoking Http.default for using a globally accessible default Http client.", "0.12.2")
+  def apply(req: Req)
+           (implicit executor: ExecutionContext): Future[Response] = default.apply(req)
+
+  @deprecated("Using the Http singleton directly is deprecated and will be removed in a future version of dispatch. Please switch to invoking Http.default for using a globally accessible default Http client.", "0.12.2")
+  def apply[T](pair: (Request, AsyncHandler[T]))
+              (implicit executor: ExecutionContext): Future[T] = default.apply(pair)
+
+  @deprecated("Using the Http singleton directly is deprecated and will be removed in a future version of dispatch. Please switch to invoking Http.default for using a globally accessible default Http client.", "0.12.2")
+  def apply[T]
+    (request: Request, handler: AsyncHandler[T])
+    (implicit executor: ExecutionContext): Future[T] = default.apply(request, handler)
 }
 
 trait HttpExecutor {

--- a/core/src/main/scala/execution.scala
+++ b/core/src/main/scala/execution.scala
@@ -9,28 +9,85 @@ import scala.util.Try
 
 /** Http executor with defaults */
 case class Http(
-                 clientBuilder: DefaultAsyncHttpClientConfig.Builder = InternalDefaults.clientBuilder
-               ) extends HttpExecutor {
-
+  clientBuilder: DefaultAsyncHttpClientConfig.Builder
+) extends HttpExecutor {
   import DefaultAsyncHttpClientConfig.Builder
 
   lazy val client = new DefaultAsyncHttpClient(clientBuilder.build)
 
-  /*§*
-    * Replaces `clientBuilder` with a new config built using the withBuilder function.
-    * The current client config is the builder's prototype.
-    */
+  /**
+   * Returns a new instance replacing the underlying `clientBuilder` with a new instance that is configured
+   * using the `withBuilder` provided. The current client config is the builder's prototype.
+   *
+   * This method may cause a resource link if you've used the Http client instance you're
+   * invoking `configure` on. For that reason it's recommended to use `closeAndConfigure` instead
+   * if you need to reconfigure an existing Http instance.
+   *
+   * If you need to preserve this behavior, it is recommended that you invoke `.copy` on the
+   * `Http` instance in ''your'' code so that it's obvious that you have created another copy of
+   * the executor and that the old one should still be maintained.
+   */
+  @deprecated("This method is deprecated and will be removed in a future version of dispatch. Please use Http.withConfiguration or closeAndConfigure. Or, optionally, directly invoke .copy on the executor and mutate the Builder yourself.", "0.13.0")
   def configure(withBuilder: Builder => Builder): Http = {
+    unsafeConfigure(withBuilder)
+  }
+
+  private[this] def unsafeConfigure(withBuilder: Builder => Builder): Http = {
     val newBuilder = new Builder(this.clientBuilder.build)
     copy(clientBuilder = withBuilder(newBuilder))
   }
+
+  /**
+   * Returns a new instance replacing the underlying `clientBuilder` with a new instance that is
+   * configured using the `withBuilder` provided. The underlying client for this instance is closed
+   * before the new instance is created in order to avoid resource leaks.
+   */
+  def closeAndConfigure(withBuilder: Builder => Builder): Http = {
+    client.close()
+    unsafeConfigure(withBuilder)
+  }
 }
 
-/** Singleton default Http executor, can be used directly or altered
-  * with its case-class `copy` */
-object Http extends Http(
-  InternalDefaults.clientBuilder
-)
+/**
+ * Singleton helper for vending Http instances.
+ *
+ * In past versions of Dispatch, this singleon was, itself, an Http executor. That could lead to
+ * a few code traps were it was possible to unintentionally allocate additional Http pools without
+ * realizing it because `Http.xxxx` and `Http().xxxx` both look very similar - yet do very different
+ * things.
+ *
+ * In the interest of avoiding such code traps in future releases of Dispatch, `Http` was changed
+ * to a helper in 0.13.x that is capable of vending a default `Http` executor instance or
+ * of configuring a custom one with its `withConfiguration` method.
+ *
+ * If you relied on the default `Http` instance in your code you can easily port
+ * your code to 0.13.x by simply invoking the `Http.default` method. Such as...
+ *
+ * {{{
+ * Http.default(localhost / "split" << Seq("str" -> str) > as.String)
+ * }}}
+ */
+object Http {
+  import DefaultAsyncHttpClientConfig.Builder
+
+  val defaultClientBuilder = InternalDefaults.clientBuilder
+
+  /**
+   * The default executor.
+   */
+  lazy val default: Http = {
+    Http(defaultClientBuilder)
+  }
+
+  /**
+   * Create an Http executor with some custom configuration defined by the `withBuilder` function
+   * that will mutate the underlying `Builder` from AHC.
+   */
+  def withConfiguration(withBuilder: Builder => Builder): Http = {
+    val newBuilder = new Builder(defaultClientBuilder.build)
+    Http(withBuilder(newBuilder))
+  }
+}
 
 trait HttpExecutor {
   self =>
@@ -64,4 +121,3 @@ trait HttpExecutor {
     client.close()
   }
 }
-

--- a/core/src/test/scala/basic.scala
+++ b/core/src/test/scala/basic.scala
@@ -69,7 +69,7 @@ with DispatchCleanup {
   }
 
   property("POST and handle") = forAll(Gen.alphaStr) { (sample: String) =>
-    val res = Http(
+    val res = Http.default(
       localhost / "echo" << Map("echo" -> sample) > as.String
     )
     res() ?= ("POST" + sample)
@@ -79,28 +79,28 @@ with DispatchCleanup {
     val headers = Map("Content-Type" -> "application/json")
     val params = Map("key" -> value)
     val body = """{"foo":"bar"}"""
-    val res = Http(
+    val res = Http.default(
       localhost / "echoquery" <:< headers <<? params << body OK  as.String
     )
     res() ?= ("POST" + "key=" + value)
   }
 
   property("POST non-ascii chars body and get response") = forAll(cyrillic) { (sample: String) =>
-    val res = Http(
+    val res = Http.default(
       localhost / "echobody" << sample > as.String
     )
     res() ?= ("POST" + sample)
   }
 
   property("GET and handle") = forAll(Gen.alphaStr) { (sample: String) =>
-    val res = Http(
+    val res = Http.default(
       localhost / "echo" <<? Map("echo" -> sample) > as.String
     )
     res() ?= ("GET" + sample)
   }
 
   property("GET and get response") = forAll(Gen.alphaStr) { (sample: String) =>
-    val res = Http(
+    val res = Http.default(
       localhost / "echo" <<? Map("echo" -> sample)
     )
     res().getResponseBody ?= ("GET" + sample)
@@ -108,7 +108,7 @@ with DispatchCleanup {
 
   property("GET with encoded path") = forAll(Gen.alphaStr) { (sample: String) =>
     // (second sample in request path is ignored)
-    val res = Http(
+    val res = Http.default(
       localhost / "echopath" / (sample + syms) / sample OK as.String
     )
     ("GET" + sample + syms) ?= res()
@@ -116,40 +116,40 @@ with DispatchCleanup {
 
   property("GET with encoded path as url") = forAll(Gen.alphaStr) { (sample: String) =>
     val requesturl = "http://127.0.0.1:%d/echopath/%s".format(server.port, URLEncoder.encode(sample + syms, "utf-8"))
-    val res = Http(url(requesturl) / sample OK as.String)
+    val res = Http.default(url(requesturl) / sample OK as.String)
     res() == ("GET" + sample + syms)
   }
 
   property("OPTIONS and handle") = forAll(Gen.alphaStr) { (sample: String) =>
-    val res = Http(
+    val res = Http.default(
       localhost.OPTIONS / "echo" <<? Map("echo" -> sample) > as.String
     )
     res() ?= ("OPTIONS" + sample)
   }
 
   property("Send Dispatch/%s User-Agent" format BuildInfo.version) = forAll(Gen.alphaStr) { (sample: String) =>
-    val res = Http(
+    val res = Http.default(
       localhost / "agent" > as.String
     )
     res() ?= ("Dispatch/%s" format BuildInfo.version)
   }
 
   property("Send a default content-type with <<") = forAll(Gen.const("unused")) { (sample: String) =>
-    val res = Http(
+    val res = Http.default(
       localhost / "contenttype" << "request body" > as.String
     )
     res() ?= ("text/plain; charset=UTF-8")
   }
 
   property("Send a custom content type after <<") = forAll(Gen.oneOf("application/json", "application/foo")) { (sample: String) =>
-    val res = Http(
+    val res = Http.default(
       (localhost / "contenttype" << "request body").setContentType(sample, Charset.forName("UTF-8")) > as.String
     )
     res() ?= (sample + "; charset=UTF-8")
   }
 
   property("Send a custom content type with <:< after <<") = forAll(Gen.oneOf("application/json", "application/foo")) { (sample: String) =>
-    val res: Future[String] = Http(
+    val res: Future[String] = Http.default(
       localhost / "contenttype" << "request body" <:< Map("Content-Type" -> sample) > as.String
     )
     res() ?= (sample)

--- a/core/src/test/scala/cleanup.scala
+++ b/core/src/test/scala/cleanup.scala
@@ -5,6 +5,6 @@ trait DispatchCleanup extends unfiltered.spec.ServerCleanup {
 
   override def cleanup() = {
     super.cleanup()
-    dispatch.Http.shutdown()
+    dispatch.Http.default.shutdown()
   }
 }

--- a/core/src/test/scala/compose.scala
+++ b/core/src/test/scala/compose.scala
@@ -8,7 +8,7 @@ with DispatchCleanup {
   import Prop.{forAll,AnyOperators}
   import Gen._
 
-  val server = { 
+  val server = {
     import unfiltered.netty
     import unfiltered.response._
     import unfiltered.request._
@@ -26,7 +26,7 @@ with DispatchCleanup {
   val localhost = host("127.0.0.1", server.port)
 
   def sum(nums: Iterable[String]) =
-    Http(localhost / "sum" << nums.map { "num" -> _ } > as.String)
+    Http.default(localhost / "sum" << nums.map { "num" -> _ } > as.String)
 
   val numList = nonEmptyListOf(chooseNum(-1000L, 1000L))
 

--- a/core/src/test/scala/fail.scala
+++ b/core/src/test/scala/fail.scala
@@ -8,7 +8,7 @@ with DispatchCleanup {
   import Prop.{forAll,AnyOperators}
   import Gen._
 
-  val server = { 
+  val server = {
     import unfiltered.netty
     import unfiltered.response._
     import unfiltered.request._
@@ -25,14 +25,14 @@ with DispatchCleanup {
   property("yield a Left on not found") = forAll(
     Gen.alphaStr.suchThat { _ != "foo"}
   ) { sample =>
-    val res = Http(localhost / sample OK as.String).either
+    val res = Http.default(localhost / sample OK as.String).either
     res() ?= Left(StatusCode(404))
   }
 
   property("project left on failure") = forAll(
     Gen.alphaStr.suchThat { _ != "foo"}
   ) { sample =>
-    val res = Http(localhost / sample OK as.String).either.right.map {
+    val res = Http.default(localhost / sample OK as.String).either.right.map {
       _ => "error"
     }
     res() ?= Left(StatusCode(404))
@@ -42,8 +42,8 @@ with DispatchCleanup {
     val path = Right(sample)
     val eth = for {
       p <- Future.successful(path).right
-      res <- Http(localhost / p OK as.String).either.right
-      res2 <- Http(localhost / p OK as.String).either.right
+      res <- Http.default(localhost / p OK as.String).either.right
+      res2 <- Http.default(localhost / p OK as.String).either.right
     } yield res2.length
     eth() ?= Right(3)
   }
@@ -56,8 +56,8 @@ with DispatchCleanup {
     val eth = for {
       g <- Future.successful(good).right
       b <- Future.successful(bad).right
-      res <- Http(localhost / g OK as.String).either.right
-      res2 <- Http(localhost / b OK as.String).either.right
+      res <- Http.default(localhost / g OK as.String).either.right
+      res2 <- Http.default(localhost / b OK as.String).either.right
     } yield res2
     eth() ?= Left(StatusCode(404))
   }

--- a/core/src/test/scala/iterable.scala
+++ b/core/src/test/scala/iterable.scala
@@ -8,7 +8,7 @@ with DispatchCleanup {
   import Prop.{forAll,AnyOperators}
   import Gen._
 
-  val server = { 
+  val server = {
     import unfiltered.netty
     import unfiltered.response._
     import unfiltered.request._
@@ -29,11 +29,11 @@ with DispatchCleanup {
   val localhost = host("127.0.0.1", server.port)
 
   def split(str: String): Future[Seq[String]] =
-    for (csv <- Http(localhost / "split" << Seq("str" -> str) > as.String))
+    for (csv <- Http.default(localhost / "split" << Seq("str" -> str) > as.String))
       yield csv.split(",")
 
   def value(str: String): Future[Int] =
-    for (v <- Http(localhost / "value" << Seq("chr" -> str) > as.String))
+    for (v <- Http.default(localhost / "value" << Seq("chr" -> str) > as.String))
       yield v.toInt
 
   property("iterable future flatMap") = forAll(Gen.alphaStr) {

--- a/core/src/test/scala/oauth/exchange.scala
+++ b/core/src/test/scala/oauth/exchange.scala
@@ -24,7 +24,7 @@ object ExchangeSpecification extends Properties("String") {
     import dispatch.oauth._
 
     trait DropboxHttp extends SomeHttp {
-      def http: HttpExecutor = Http
+      def http: HttpExecutor = Http.default
     }
 
     trait DropboxConsumer extends SomeConsumer {

--- a/core/src/test/scala/retry.scala
+++ b/core/src/test/scala/retry.scala
@@ -8,7 +8,7 @@ with DispatchCleanup {
   import Prop.{forAll,AnyOperators}
   import Gen._
 
-  val server = { 
+  val server = {
     import unfiltered.netty
     import unfiltered.response._
     import unfiltered.request._
@@ -39,7 +39,7 @@ with DispatchCleanup {
   class RetryCounter {
     private val retried = new java.util.concurrent.atomic.AtomicInteger
     def succeedOn(successRetry: Int)() = {
-      Http(localhost << Map("echo" -> retried.getAndIncrement.toString)
+      Http.default(localhost << Map("echo" -> retried.getAndIncrement.toString)
            OK as.String).either.map { eth =>
         eth.right.flatMap { numstr =>
           val num = numstr.toInt

--- a/core/src/test/scala/server.scala
+++ b/core/src/test/scala/server.scala
@@ -9,7 +9,7 @@ with DispatchCleanup {
 
   import dispatch._
 
-  val server = { 
+  val server = {
     import unfiltered.netty
     import unfiltered.response._
     import unfiltered.request._
@@ -21,7 +21,7 @@ with DispatchCleanup {
         req.respond(PlainTextContent ~> ResponseString(echo))
       case req @ Path("/ask") & Params(Echo(echo) & What(what)) =>
         for {
-          e <- Http(
+          e <- Http.default(
             localhost / what << Map("echo" -> echo) OK as.String
           ).either
         } {
@@ -32,7 +32,7 @@ with DispatchCleanup {
         }
       case req @ Path("/ask") & Params(What(what)) & EchoHeader(echo) =>
         for {
-          e <- Http(
+          e <- Http.default(
             localhost / what << Map("echo" -> echo) OK as.String
           ).either
         } {
@@ -48,7 +48,7 @@ with DispatchCleanup {
 
   property("Server receieves same answer (from param) from itself") =
     forAll(Gen.alphaStr) { sample =>
-      val res: Future[String] = Http(
+      val res: Future[String] = Http.default(
         localhost / "ask" << Map("what" -> "echo",
                                  "echo" -> sample) > as.String
       )
@@ -57,7 +57,7 @@ with DispatchCleanup {
 
   property("Server receives same answer (from header) from itself") =
     forAll(Gen.alphaStr) { sample =>
-      val res = Http(
+      val res = Http.default(
         (localhost / "ask") << Map("what" -> "echo") <:< Map("echo" -> sample) > as.String
       )
       res() ?= sample
@@ -66,7 +66,7 @@ with DispatchCleanup {
   property("Backend failure produces error response") =
     forAll(Gen.alphaStr.suchThat { _ != "echo"}, Gen.alphaStr) {
       (sample1, sample2) =>
-        val res = Http(
+        val res = Http.default(
           localhost / "ask" << Map("what" -> sample1,
                                    "echo" -> sample2) OK as.String
         ).either

--- a/core/src/test/scala/uri.scala
+++ b/core/src/test/scala/uri.scala
@@ -8,7 +8,7 @@ object UriSpecification extends Properties("Uri") {
    *  because it implements completely different functionality: query parameter decoding
    */
   property("encode-decode") = Prop.forAll { (path: String) =>
-    !path.contains(":") ==> { 
+    !path.contains(":") ==> {
       new java.net.URI(dispatch.UriEncode.path(path)).getPath == path
     } // else Prop.throws(classOf[java.net.URISyntaxException])
   }

--- a/json4sjackson/src/test/scala/json.scala
+++ b/json4sjackson/src/test/scala/json.scala
@@ -39,7 +39,7 @@ with DispatchCleanup {
   def localhost = host("127.0.0.1", server.port)
 
   property("parse json") = forAll(Gen.alphaStr) { (sample: String) =>
-    val res = Http(
+    val res = Http.default(
       localhost <:< Map("Accept" -> "application/json") <<? Map("in" -> sample) > as.json4s.Json
     )
     sample == (for { JObject(fields) <- res(); JField("out", JString(o)) <- fields } yield o).head

--- a/json4snative/src/test/scala/json.scala
+++ b/json4snative/src/test/scala/json.scala
@@ -39,7 +39,7 @@ with DispatchCleanup {
   def localhost = host("127.0.0.1", server.port)
 
   property("parse json") = forAll(Gen.alphaStr) { (sample: String) =>
-    val res = Http(
+    val res = Http.default(
       localhost <:< Map("Accept" -> "application/json") <<? Map("in" -> sample) > as.json4s.Json
     )
     sample == (for { JObject(fields) <- res(); JField("out", JString(o)) <- fields } yield o).head

--- a/jsoup/src/test/scala/soup.scala
+++ b/jsoup/src/test/scala/soup.scala
@@ -37,21 +37,21 @@ with DispatchCleanup {
   def localhost = host("127.0.0.1", server.port)
 
   property("handle Documents") = forAll(Gen.alphaStr) { (sample: String) =>
-    val doc = Http(
+    val doc = Http.default(
       localhost / "echo" <<? Map("echo" -> sample) > as.jsoup.Document
-    )  
+    )
     doc().select("div#echo").first().text() == sample
   }
 
   property("handle Queries") = forAll(Gen.alphaStr) { (sample: String) =>
-    val els = Http(
+    val els = Http.default(
       localhost / "echo" <<? Map("echo" -> sample) > as.jsoup.Query("div")
     )
     els().first().text() == sample
   }
 
   property("handle Cleaning") = forAll(Gen.alphaStr) { (sample: String) =>
-    val clean = Http(
+    val clean = Http.default(
       localhost / "unclean" <<? Map("echo" -> sample) > as.jsoup.Clean(
         Whitelist.basic)
     )
@@ -59,7 +59,7 @@ with DispatchCleanup {
   }
 
   property("handle absolute urls on page") = forAll(Gen.alphaStr) { (sample: String) =>
-    val doc = Http(
+    val doc = Http.default(
       localhost / "relative" <<? Map("echo" -> sample) > as.jsoup.Document
     )
     doc().select("a").first().absUrl("href") == (localhost.url + "category")

--- a/tagsoup/src/test/scala/soup.scala
+++ b/tagsoup/src/test/scala/soup.scala
@@ -23,7 +23,7 @@ with DispatchCleanup {
   def localhost = host("127.0.0.1", server.port)
 
   property("handle documents") = forAll(Gen.alphaStr) { (sample: String) =>
-    val doc = Http(
+    val doc = Http.default(
       localhost / "echo" <<? Map("echo" -> sample) > as.tagsoup.NodeSeq
     )
     (doc() \\ "div").find (n => (n \ "@id").text == "echo").map (_.text) .mkString == (sample)


### PR DESCRIPTION
This commit forward-ports the API changes from dispatch/reboot#156 into
the 0.13.x release series with a few important changes to boot.

The first, and perhaps biggest, change is that the Http singleton is no
longer an Http executor in it own right. This will no doubt cause some
code breakage that has to be addressed as folks upgrade to 0.13.x. In
order to minimize that code breakage, Http.default provides a default
executor that is always usable for just "doing some HTTP" without
further customization.

This will make explicit the fact that you're invoking a real Thing™ that
has resources that will need to be cleaned up when you're done using
them. This was something that could be ambiguous in earlier versions of
Dispatch because if you happened to invoke `Http()` instead of `Http`
you'd get a new resource pool each time and quickly create problems for
yourself. Two characters should not make that much of a difference in
behavior.

Furthermore, we no longer provide the default builder to the Http case
class by default. It's accessable at Http.defaultClientBuilder if you
wish to use it.

This also adds Http.withConfiguration to facilitate configuring custom
Http instances.