### PR TITLE
Bump AHC version to 1.9.40.

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,7 +4,7 @@ description :=
   "Core Dispatch module wrapping sonatype/async-http-client"
 
 libraryDependencies +=
-  "com.ning" % "async-http-client" % "1.9.11"
+  "com.ning" % "async-http-client" % "1.9.40"
 
 Seq(lsSettings :_*)
 


### PR DESCRIPTION
This bumps the AHC version in Dispatch 0.12.x to the latest in the 1.9 series: 1.9.40.