### PR TITLE
Fix as.File descriptor leak

### DIFF
--- a/core/src/main/scala/handlers.scala
+++ b/core/src/main/scala/handlers.scala
@@ -1,5 +1,6 @@
 package dispatch
 
+import java.io.Closeable
 import org.asynchttpclient.{
   Response, AsyncCompletionHandler, AsyncHandler,
   HttpResponseStatus
@@ -34,5 +35,22 @@ trait OkHandler[T] extends AsyncHandler[T] {
       super.onStatusReceived(status)
     else
       throw StatusCode(status.getStatusCode)
+  }
+}
+
+/**
+ * A trait to ensure some set of closeable resources are closed in the event of a throwable occuring
+ * during a request. This can be combined with other AsyncHandlers, for example the OkHandler
+ * provided by Dispatch, to ensure that any closeable resources are cleanly shut down in the event
+ * of an exception.
+ *
+ * See the implementation of [[dispatch.as.File]] for an example of how this is used.
+ */
+trait CloseResourcesOnThrowableHandler[T] extends AsyncHandler[T] {
+  def closeable: Seq[Closeable]
+
+  abstract override def onThrowable(error: Throwable): Unit = {
+    closeable.foreach(_.close())
+    super.onThrowable(error)
   }
 }


### PR DESCRIPTION
This PR fixes the descriptor leak in `as.File` and provides a new `AsyncHandler` called `CloseResourcesOnThrowableHandler` that should be generally useful.

fixes #119 