### PR TITLE
[0.13.x] Bump the lift-json dependency to 3.1.0.

### DIFF
--- a/liftjson/build.sbt
+++ b/liftjson/build.sbt
@@ -8,6 +8,6 @@ scalacOptions += "-Xfatal-warnings"
 Seq(lsSettings :_*)
 
 libraryDependencies ++= Seq(
-  "net.liftweb" %% "lift-json" % "3.0.1",
+  "net.liftweb" %% "lift-json" % "3.1.0",
   "org.mockito" % "mockito-core" % "1.10.19" % "test"
 )


### PR DESCRIPTION
Backport of #170.

See #161.