### PR TITLE
Change organization and URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The following instructions will get you your snapshot:
 resolvers +=
   "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
-libraryDependencies += "net.databinder.dispatch" %% "dispatch-core" % "0.14.0-SNAPSHOT"
+libraryDependencies += "org.dispatchhttp" %% "dispatch-core" % "0.14.0-SNAPSHOT"
 ```
 
 ## Versioning and Support

--- a/project/common.scala
+++ b/project/common.scala
@@ -42,10 +42,10 @@ object Common {
       )
     },
 
-    organization := "net.databinder.dispatch",
+    organization := "org.dispatchhttp",
 
     homepage :=
-      Some(new java.net.URL("http://dispatch.databinder.net/")),
+      Some(new java.net.URL("https://dispatchhttp.org/")),
 
     publishMavenStyle := true,
 


### PR DESCRIPTION
See #174 

This changes the coordinates of Dispatch on Maven central from `net.databinder.dispatch` to `org.dispatchhttp`. There will need to be some readme changes that come once we do a release, but for now this will make the change in the build.