### PR TITLE
Document that FunctionHandler isn't thread safe

### DIFF
--- a/core/src/main/scala/handlers.scala
+++ b/core/src/main/scala/handlers.scala
@@ -22,6 +22,7 @@ class RequestHandlerTupleBuilder(req: Req) {
 case class StatusCode(code: Int)
 extends Exception("Unexpected response status: %d".format(code))
 
+/** This class is not thread safe. A new instance should be used for each callback */
 class FunctionHandler[T](f: Response => T) extends AsyncCompletionHandler[T] {
   def onCompleted(response: Response) = f(response)
 }


### PR DESCRIPTION
Clarify that FunctionHandler inherits from a mutable class AsyncCompletionHandler, and therefore each callback should be handled by a fresh instance. 

This PR arose from an actual bug "in the wild" at REA Group in Australia which expended considerable effort to track down. Its an easy mistake to make and Im keen to save the next user from the same confusion.