### PR TITLE
Bump async-http-client to 2.0.35

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,7 +4,7 @@ description :=
   "Core Dispatch module wrapping async-http-client"
 
 libraryDependencies +=
-  "org.asynchttpclient" % "async-http-client" % "2.0.33"
+  "org.asynchttpclient" % "async-http-client" % "2.0.35"
 
 Seq(lsSettings :_*)
 


### PR DESCRIPTION
That version fixes a security issue:
https://github.com/AsyncHttpClient/async-http-client/issues/1455

https://nvd.nist.gov/vuln/detail/CVE-2017-14063