### PR TITLE
Bump AHC to 2.0.38

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,7 +4,7 @@ description :=
   "Core Dispatch module wrapping async-http-client"
 
 libraryDependencies +=
-  "org.asynchttpclient" % "async-http-client" % "2.0.36"
+  "org.asynchttpclient" % "async-http-client" % "2.0.38"
 
 Seq(lsSettings :_*)
 


### PR DESCRIPTION
This verison bumps AHC in the 0.13 series to the latest, 2.0.38.