### PR TITLE
fix procedure syntax warnings

### DIFF
--- a/ufcheck/src/test/scala/cleanup.scala
+++ b/ufcheck/src/test/scala/cleanup.scala
@@ -2,19 +2,19 @@ package unfiltered.spec
 
 trait Cleanup {
   Cleanup.dirties += this
-  def cleanup()
+  def cleanup(): Unit
 }
 
 trait ServerCleanup extends Cleanup {
   def server: unfiltered.util.StartableServer
-  def cleanup() { server.stop() }
+  def cleanup(): Unit = { server.stop() }
 }
 
 object Cleanup {
   import scala.collection.mutable.{HashSet,SynchronizedSet}
   private val dirties = new HashSet[Cleanup] with SynchronizedSet[Cleanup]
 
-  def cleanup() {
+  def cleanup(): Unit = {
     try {
       dirties.foreach { _.cleanup() }
     } catch {


### PR DESCRIPTION
```
[warn] /home/travis/build/dispatch/reboot/ufcheck/src/test/scala/cleanup.scala:5:16: Procedure syntax is deprecated. Convert procedure `cleanup` to method by adding `: Unit`.
[warn]   def cleanup()
[warn]                ^
[warn] /home/travis/build/dispatch/reboot/ufcheck/src/test/scala/cleanup.scala:10:17: Procedure syntax is deprecated. Convert procedure `cleanup` to method by adding `: Unit =`.
[warn]   def cleanup() { server.stop() }
[warn]                 ^
[warn] /home/travis/build/dispatch/reboot/ufcheck/src/test/scala/cleanup.scala:17:17: Procedure syntax is deprecated. Convert procedure `cleanup` to method by adding `: Unit =`.
[warn]   def cleanup() {
[warn]                 ^
```