### PR TITLE
Bump AHC to 2.0.39

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,7 +4,7 @@ description :=
   "Core Dispatch module wrapping async-http-client"
 
 libraryDependencies +=
-  "org.asynchttpclient" % "async-http-client" % "2.0.38"
+  "org.asynchttpclient" % "async-http-client" % "2.0.39"
 
 Seq(lsSettings :_*)
 


### PR DESCRIPTION
This bumps AHC to the latest in the 2.0 series: 2.0.39.