### PR TITLE
Upgrade to AHC 2.4.7 for Dispatch 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,12 @@ their current support status:
 |0.12.3            |1.9.40        |2.11,2.12      |Critical only |0.12.x                           |
 |0.13.3            |2.0.38        |2.11,2.12      |Full support  |0.13.x                           |
 |0.14.0            |2.1.2         |2.11,2.12      |Full support  |0.14.x                           |
-|1.0.0-SNAPSHOT    |2.1.2         |2.11,2.12      |Development   |master                           |
+|1.0.0-SNAPSHOT    |2.4.7         |2.11,2.12      |Development   |master                           |
+
+Because the AsyncHttpClient does not adhere to semantic versioning, and its versions can increment
+quite quickly at times, beginning with 0.14 Dispatch will only use the latest (major, minor) AHC
+version that's available at the time its being developed. You may not be able to find a Dispatch
+version for every version of AHC if AHC went through a quick release clip.
 
 ## Getting Help and Contributing
 

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,7 +4,7 @@ description :=
   "Core Dispatch module wrapping async-http-client"
 
 libraryDependencies +=
-  "org.asynchttpclient" % "async-http-client" % "2.1.2"
+  "org.asynchttpclient" % "async-http-client" % "2.4.7"
 
 enablePlugins(BuildInfoPlugin)
 

--- a/core/src/main/scala/oauth/exchange.scala
+++ b/core/src/main/scala/oauth/exchange.scala
@@ -4,7 +4,7 @@ import dispatch._
 import io.netty.handler.codec.http.HttpHeaderNames
 import org.asynchttpclient._
 import org.asynchttpclient.oauth._
-import org.asynchttpclient.util.Base64
+import java.util.Base64
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -42,7 +42,7 @@ trait Exchange {
 
   def generateNonce = nonceBuffer.synchronized {
     random.nextBytes(nonceBuffer)
-    Base64.encode(nonceBuffer)
+    Base64.getEncoder().encodeToString(nonceBuffer)
   }
 
   def message[A](promised: Future[A], ctx: String)

--- a/core/src/main/scala/stream/strings.scala
+++ b/core/src/main/scala/stream/strings.scala
@@ -19,7 +19,7 @@ trait Strings[T] extends AsyncHandler[T] {
   def onHeadersReceived(headers: HttpHeaders) = {
     for {
       ct <- Option(headers.get(CONTENT_TYPE))
-      cs <- Option(HttpUtils.extractCharset(ct))
+      cs <- Option(HttpUtils.extractContentTypeCharsetAttribute(ct))
     } charset = cs
     state
   }


### PR DESCRIPTION
Upgrades to the latest AHC version and makes the required API changes.