### PR TITLE
fix scalacOptions for Scala 2.13

### DIFF
--- a/project/common.scala
+++ b/project/common.scala
@@ -27,12 +27,20 @@ object Common {
       "-language:implicitConversions",
       // "-Xfatal-warnings",
       "-Xlint",
-      "-Yno-adapted-args",
       "-Ywarn-dead-code",
       "-Ywarn-numeric-widen",
       "-Ywarn-value-discard",
       "-Xfuture"
     ),
+
+    scalacOptions in (Compile) ++= {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, v)) if v <= 12 =>
+          Seq("-Yno-adapted-args")
+        case _ =>
+          Nil
+      }
+    },
 
     scalacOptions in (Test) ~= { (opts: Seq[String]) =>
       opts.diff(


### PR DESCRIPTION
"-Yno-adapted-args" removed since Scala 2.13.0-M4
https://github.com/scala/scala/commit/a82a56ea5ba1ff0fb3b69c0963d4aec620ab68ad