### PR TITLE
fix warnings

### DIFF
--- a/core/src/test/scala/retry.scala
+++ b/core/src/test/scala/retry.scala
@@ -55,19 +55,19 @@ with DispatchCleanup {
 
   property("succeed on the first request") = forAll(smallNums) { maxRetries =>
     val rc = new RetryCounter
-    val p = retry.Backoff(maxRetries)(rc.succeedOn(0))
+    val p = retry.Backoff(maxRetries)(() => rc.succeedOn(0))
     p() ?= Right(0)
   }
 
   property("succeed on the max retry") = forAll(smallNums) { maxRetries =>
     val rc = new RetryCounter
-    val p = retry.Directly(maxRetries)(rc.succeedOn(maxRetries))
+    val p = retry.Directly(maxRetries)(() => rc.succeedOn(maxRetries))
     p() ?= Right(maxRetries)
   }
 
   property("fail after max retries") = forAll(smallNums) { maxRetries =>
     val rc = new RetryCounter
-    val p = retry.Directly(maxRetries)(rc.succeedOn(maxRetries + 1))
+    val p = retry.Directly(maxRetries)(() => rc.succeedOn(maxRetries + 1))
     p() ?= Left(maxRetries)
   }
 
@@ -76,7 +76,7 @@ with DispatchCleanup {
     val p = retry.Backoff(
       max,
       Duration(2, TimeUnit.MICROSECONDS)
-    )(rc.succeedOn(max))
+    )(() => rc.succeedOn(max))
     p() ?= Right(max)
   }
 
@@ -85,7 +85,7 @@ with DispatchCleanup {
     val p = retry.Pause(
       max,
       Duration(500, TimeUnit.MICROSECONDS)
-    )(rc.succeedOn(max + 1))
+    )(() => rc.succeedOn(max + 1))
     p() ?= Left(max)
   }
 }


### PR DESCRIPTION
https://travis-ci.org/dispatch/reboot/jobs/392777259#L719

```
[warn] /home/travis/build/dispatch/reboot/core/src/test/scala/retry.scala:58:51: Eta-expansion of zero-argument methods is deprecated. To avoid this warning, write (() => rc.succeedOn(0)()).
[warn]     val p = retry.Backoff(maxRetries)(rc.succeedOn(0))
[warn]                                                   ^
[warn] /home/travis/build/dispatch/reboot/core/src/test/scala/retry.scala:64:52: Eta-expansion of zero-argument methods is deprecated. To avoid this warning, write (() => rc.succeedOn(maxRetries)()).
[warn]     val p = retry.Directly(maxRetries)(rc.succeedOn(maxRetries))
[warn]                                                    ^
[warn] /home/travis/build/dispatch/reboot/core/src/test/scala/retry.scala:70:52: Eta-expansion of zero-argument methods is deprecated. To avoid this warning, write (() => rc.succeedOn(maxRetries.+(1))()).
[warn]     val p = retry.Directly(maxRetries)(rc.succeedOn(maxRetries + 1))
[warn]                                                    ^
[warn] /home/travis/build/dispatch/reboot/core/src/test/scala/retry.scala:79:19: Eta-expansion of zero-argument methods is deprecated. To avoid this warning, write (() => rc.succeedOn(max)()).
[warn]     )(rc.succeedOn(max))
[warn]                   ^
[warn] /home/travis/build/dispatch/reboot/core/src/test/scala/retry.scala:88:19: Eta-expansion of zero-argument methods is deprecated. To avoid this warning, write (() => rc.succeedOn(max.+(1))()).
[warn]     )(rc.succeedOn(max + 1))
[warn]                   ^
[warn] 5 warnings found
```