### PR TITLE
[1.0] Allow to set scheme in as keyword

### DIFF
--- a/core/src/main/scala/requests.scala
+++ b/core/src/main/scala/requests.scala
@@ -271,8 +271,8 @@ trait ParamVerbs extends RequestVerbs {
 }
 
 trait AuthVerbs extends RequestVerbs {
-  def as(user: String, password: String): Req =
-    this.as(new Realm.Builder(user, password).build())
+  def as(user: String, password: String, scheme: AuthScheme): Req =
+    this.as(new Realm.Builder(user, password).setScheme(scheme).build())
 
   /** Basic auth, use with care. */
   def as_!(user: String, password: String): Req =

--- a/core/src/test/scala/basic.scala
+++ b/core/src/test/scala/basic.scala
@@ -2,7 +2,10 @@ package dispatch.spec
 
 import java.nio.charset.Charset
 
+import org.asynchttpclient.Realm
+import org.asynchttpclient.Realm.AuthScheme
 import org.scalacheck._
+import org.scalacheck.Prop._
 
 object BasicSpecification
 extends Properties("Basic")
@@ -164,6 +167,21 @@ with DispatchCleanup {
       val expectedParams = sample.map { case (key, value) => "%s=%s".format(key, value) }
       val req = localhost.setBody("").setContentType("text/plain", Charset.forName("UTF-8")) <<? sample
       req.toRequest.getUrl ?= "http://127.0.0.1:%d/?%s".format(port, expectedParams.mkString("&"))
+    }
+  }
+
+  property("Building a Realm without a scheme should throw NPE") = {
+    forAll(Gen.zip(Gen.alphaNumStr, Gen.alphaNumStr)) { case (user, password) =>
+      throws(classOf[NullPointerException])(new Realm.Builder(user, password).build())
+    }
+  }
+
+  property("Build a Realm using as") = {
+    forAll(Gen.zip(Gen.alphaNumStr, Gen.alphaNumStr, Gen.oneOf(AuthScheme.values()))) { case (user, password, scheme) =>
+      val realm = localhost.as(user, password, scheme).toRequest.getRealm
+      realm.getScheme ?= scheme
+      realm.getPrincipal ?= user
+      realm.getPassword ?= password
     }
   }
 }


### PR DESCRIPTION
Backport of #206 to the 1.0 series.

This is a breaking API change, but the original API didn't work properly _anyway_ so this qualifies for a bugfix release.