### PR TITLE
[0.14] Allow to set scheme in as keyword

### DIFF
--- a/core/src/main/scala/requests.scala
+++ b/core/src/main/scala/requests.scala
@@ -271,8 +271,8 @@ trait ParamVerbs extends RequestVerbs {
 }
 
 trait AuthVerbs extends RequestVerbs {
-  def as(user: String, password: String): Req =
-    this.as(new Realm.Builder(user, password).build())
+  def as(user: String, password: String, scheme: AuthScheme): Req =
+    this.as(new Realm.Builder(user, password).setScheme(scheme).build())
 
   /** Basic auth, use with care. */
   def as_!(user: String, password: String): Req =


### PR DESCRIPTION
Backport of #206 to the 0.14 series.

This is a breaking API change, but the original API didn't work properly to begin with so we're correcting it in a patch release.