### PR TITLE
Fix explicit method setting

### DIFF
--- a/core/src/main/scala/oauth/requests.scala
+++ b/core/src/main/scala/oauth/requests.scala
@@ -8,10 +8,10 @@ class SigningVerbs(val subject: Req) extends RequestVerbs {
 
   def sign(consumer: ConsumerKey, token: RequestToken = emptyToken) = {
     val calc = new OAuthSignatureCalculator(consumer, token)
-    subject underlying { r =>
+    subject.underlying({ r =>
       calc.calculateAndAddSignature(r.build, r)
       r
-    }
+    }, subject.methodExplicitlySet)
   }
 
   def <@(consumer: ConsumerKey, token: RequestToken = emptyToken) =

--- a/core/src/test/scala/basic.scala
+++ b/core/src/test/scala/basic.scala
@@ -96,6 +96,20 @@ with DispatchCleanup {
     res() ?= ("POST" + sample)
   }
 
+  property("PUT alphaString body with setBody and get response") = forAll(Gen.alphaStr) { (sample: String) =>
+    val res = Http.default(
+      (localhost / "echobody").PUT.setBody(sample) > as.String
+    )
+    res() ?= ("PUT" + sample)
+  }
+
+  property("PUT alphaString body with << and get response") = forAll(Gen.alphaStr) { (sample: String) =>
+    val res = Http.default(
+      (localhost / "echobody").PUT << sample > as.String
+    )
+    res() ?= ("PUT" + sample)
+  }
+
   property("GET and handle") = forAll(Gen.alphaStr) { (sample: String) =>
     val res = Http.default(
       localhost / "echo" <<? Map("echo" -> sample) > as.String


### PR DESCRIPTION
As mentioned in https://github.com/dispatch/reboot/issues/216, there is a bug between two lines that are equivalent. It is happening because the `underlying` functions of `Req`  create a new `Req`, so we lose the value of the `explicitlyMethodSet`

To fix, I made `explicitlyMethodSet` part of the `Req` and the `underlying` functions. Was trying to make it a default parameter, but could not be that as `Req` is a case class.

Thanks to @stephennancekivell for the test case!