### PR TITLE
Add explicit support for empty query parameters

### DIFF
--- a/core/src/main/scala/requests.scala
+++ b/core/src/main/scala/requests.scala
@@ -324,11 +324,11 @@ trait RequestBuilderVerbs extends RequestVerbs {
   }
 
   /**
-   * Add a new query parameter to the request. Supports an optionally empty
-   * value.
+   * Add a new query parameter to the request without a value. This is useful
+   * for some APIs that require adding just the key to the query parameters
    */
-  def addQueryParameter(name: String, value: Option[String]) {
-    subject.underlying(_.addQueryParam(name, value.getOrElse(null)))
+  def addQueryParameter(name: String) = {
+    subject.underlying(_.addQueryParam(name, null))
   }
 
   /**

--- a/core/src/main/scala/requests.scala
+++ b/core/src/main/scala/requests.scala
@@ -324,6 +324,14 @@ trait RequestBuilderVerbs extends RequestVerbs {
   }
 
   /**
+   * Add a new query parameter to the request. Supports an optionally empty
+   * value.
+   */
+  def addQueryParameter(name: String, value: Option[String]) {
+    subject.underlying(_.addQueryParam(name, value.getOrElse(null)))
+  }
+
+  /**
    * Set query parameters, overwriting any pre-existing query parameters.
    */
   def setQueryParameters(params: Map[String, Seq[String]]) = {

--- a/core/src/test/scala/basic.scala
+++ b/core/src/test/scala/basic.scala
@@ -189,6 +189,11 @@ with DispatchCleanup {
     req.toRequest.getUrl ?= "http://127.0.0.1:%d/path?key".format(port)
   }
 
+  property("Set query params with just the key") = forAll(Gen.const("unused")) { (sample: String) =>
+    val req = (localhost / "path").setQueryParameters(Map("key" -> Seq()))
+    req.toRequest.getUrl ?= "http://127.0.0.1:%d/path?key".format(port)
+  }
+
   property("Building a Realm without a scheme should throw NPE") = {
     forAll(Gen.zip(Gen.alphaNumStr, Gen.alphaNumStr)) { case (user, password) =>
       throws(classOf[NullPointerException])(new Realm.Builder(user, password).build())

--- a/core/src/test/scala/basic.scala
+++ b/core/src/test/scala/basic.scala
@@ -184,6 +184,11 @@ with DispatchCleanup {
     }
   }
 
+  property("Add query params with just the key") = forAll(Gen.const("unused")) { (sample: String) =>
+    val req = (localhost / "path").addQueryParameter("key")
+    req.toRequest.getUrl ?= "http://127.0.0.1:%d/path?key".format(port)
+  }
+
   property("Building a Realm without a scheme should throw NPE") = {
     forAll(Gen.zip(Gen.alphaNumStr, Gen.alphaNumStr)) { case (user, password) =>
       throws(classOf[NullPointerException])(new Realm.Builder(user, password).build())

--- a/project/common.scala
+++ b/project/common.scala
@@ -9,7 +9,8 @@ object Common {
     testOptions in Test += Tests.Cleanup { loader =>
       val c = loader.loadClass("unfiltered.spec.Cleanup$")
       c.getMethod("cleanup").invoke(c.getField("MODULE$").get(c))
-    }
+    },
+    testOptions in Test += Tests.Argument(TestFrameworks.ScalaCheck, "-verbosity", "3")
   )
 
   val settings: Seq[Setting[_]] = Seq(


### PR DESCRIPTION
Fixes #224 — This adds explicit support for query parameters with a key and no value in our API. I'm pretty sure these changes won't require a major version bump but I want to take a look at it in a bit to be sure. It's probably also worth me doing some doc site updates to make this behavior more visible.

/cc @hbergmey