### PR TITLE
Correctly url encode emoji in path segments

### DIFF
--- a/core/src/test/scala/uri.scala
+++ b/core/src/test/scala/uri.scala
@@ -1,21 +1,26 @@
 package dispatch.spec
 
 import org.scalacheck._
-import org.scalacheck.Prop.BooleanOperators
+import org.scalacheck.Prop._
 
 object UriSpecification extends Properties("Uri") {
   /** java.net.URLDecoder should *NOT* be used for testing URI segment decoding
    *  because it implements completely different functionality: query parameter decoding
    */
-  property("encode-decode") = Prop.forAll { (path: String) =>
+  property("Encodes and decodes basic strings") = Prop.forAll { (path: String) =>
     !path.contains(":") ==> {
       new java.net.URI(dispatch.UriEncode.path(path)).getPath == path
     } // else Prop.throws(classOf[java.net.URISyntaxException])
   }
 
   /** if there is nothing to escape, encoder must return original reference */
-  property("noop") = Prop.forAll(Gen.choose(0,100)) { (n: Int) =>
+  property("Does nothing if there's nothing eo encode") = Prop.forAll(Gen.choose(0,100)) { (n: Int) =>
     val path = "A" * n
     dispatch.UriEncode.path(path) eq path
+  }
+
+  property("Encodes emoji correctly") = forAll(Gen.const("unused")) { (sample: String) =>
+    val path = "roma🇮🇹"
+    new java.net.URI(dispatch.UriEncode.path(path)).getPath == (path)
   }
 }


### PR DESCRIPTION
Closes #213 

The previous implementation borked on emoji because invoking
char.toString on a single UTF-8 part of a larger UTF-16 pair results in
the encoding presenting "?" as the value.

This implementation works primarily on Bytes and avoids having to invoke
char.toString and therefore is capable of correctly encoding emoji
characters into a UTF-8 url encoded path segment.

This did involve re-working some of the valid character detection for
path segments, so there is likely a delta to the overall performance,
but I think it should be negligible.