### PR TITLE
Bump AHC to 3.0.1

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,7 +4,7 @@ description :=
   "Core Dispatch module wrapping async-http-client"
 
 libraryDependencies +=
-  "org.asynchttpclient" % "async-http-client" % "3.0.0"
+  "org.asynchttpclient" % "async-http-client" % "3.0.1"
 
 enablePlugins(BuildInfoPlugin)
 

--- a/core/src/main/scala/requests.scala
+++ b/core/src/main/scala/requests.scala
@@ -485,6 +485,14 @@ trait RequestBuilderVerbs extends RequestVerbs {
   }
 
   /**
+   * Add a cookie based on its name, if it does not exist yet. Cookies that
+   * are already set will be ignored.
+   */
+  def addCookieIfUnset(cookie: Cookie) = {
+    subject.underlying(_.addCookieIfUnset(cookie))
+  }
+
+  /**
    * Set auth realm
    */
   def setRealm(realm: Realm) = {


### PR DESCRIPTION
AHC 3.0.1 has a [Critical CVE](https://nvd.nist.gov/vuln/detail/CVE-2024-53990) which is causing downstream consumers of dispatch to get vulnerability alerts.

Included in 3.0.1 are a few dependency upgrades in addition to the fix for the CVE. AHC [considers 3.0.1 as breaking release](https://github.com/AsyncHttpClient/async-http-client/releases/tag/async-http-client-project-3.0.1) as they've added a new method to the abstract RequestBuilderBase class.

Worth noting that the behaviour of the default client has changed slightly in order to fix the CVE. Previously cookies found in the cookie jar would replace cookies in the RequestBuilder, this is no longer the case.

Not quite sure about the branch layout of this repo! Should this change go to the `2.0.x` branch?